### PR TITLE
feat: #1 ERD 기반 초기 엔티티 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,9 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
+def queryDslVersion = "6.11"
+apply from: 'setting/querydsl.gradle'
+
 group = 'com.wholeseeds'
 version = '0.0.1-SNAPSHOT'
 
@@ -45,6 +48,11 @@ dependencies {
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.0' // SQL 이쁘게 포멧팅 라이브러리
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0' // swagger-ui
     implementation 'org.hibernate.validator:hibernate-validator'
+
+    // OpenFeign QueryDSL
+    implementation("io.github.openfeign.querydsl:querydsl-core:${queryDslVersion}")
+    implementation("io.github.openfeign.querydsl:querydsl-jpa:$queryDslVersion")
+    annotationProcessor("io.github.openfeign.querydsl:querydsl-apt:$queryDslVersion:jpa")
 }
 
 tasks.named('test') {

--- a/setting/querydsl.gradle
+++ b/setting/querydsl.gradle
@@ -1,0 +1,16 @@
+def querydslSrcDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
+
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(file(querydslSrcDir))
+}
+
+sourceSets {
+    main {
+        java {
+            srcDirs += querydslSrcDir
+        }
+    }
+}
+configurations {
+    querydsl.extendsFrom compileClasspath
+}

--- a/src/main/java/com/wholeseeds/mindle/common/entity/BaseEntity.java
+++ b/src/main/java/com/wholeseeds/mindle/common/entity/BaseEntity.java
@@ -1,0 +1,42 @@
+package com.wholeseeds.mindle.common.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+public abstract class BaseEntity {
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	protected LocalDateTime createdAt;
+
+	@Column(name = "updated_at")
+	protected LocalDateTime updatedAt;
+
+	@Column(name = "deleted_at")
+	protected LocalDateTime deletedAt;
+
+	@PrePersist
+	protected void onCreate() {
+		this.createdAt = LocalDateTime.now();
+		this.updatedAt = this.createdAt;
+	}
+
+	@PreUpdate
+	protected void onUpdate() {
+		this.updatedAt = LocalDateTime.now();
+	}
+
+	public void softDelete() {
+		this.deletedAt = LocalDateTime.now();
+	}
+
+	public boolean isDeleted() {
+		return this.deletedAt != null;
+	}
+}

--- a/src/main/java/com/wholeseeds/mindle/common/entity/BaseEntity.java
+++ b/src/main/java/com/wholeseeds/mindle/common/entity/BaseEntity.java
@@ -3,6 +3,9 @@ package com.wholeseeds.mindle.common.entity;
 import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
@@ -11,6 +14,10 @@ import lombok.Getter;
 @Getter
 @MappedSuperclass
 public abstract class BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
 	@Column(name = "created_at", nullable = false, updatable = false)
 	protected LocalDateTime createdAt;

--- a/src/main/java/com/wholeseeds/mindle/common/repository/JpaBaseRepository.java
+++ b/src/main/java/com/wholeseeds/mindle/common/repository/JpaBaseRepository.java
@@ -1,4 +1,11 @@
 package com.wholeseeds.mindle.common.repository;
 
-public class JpaBaseRepository {
+import java.util.List;
+import java.util.Optional;
+
+public interface JpaBaseRepository<T, ID> {
+
+	Optional<T> findByIdNotDeleted(ID id);
+
+	List<T> findAllNotDeleted();
 }

--- a/src/main/java/com/wholeseeds/mindle/common/repository/JpaBaseRepository.java
+++ b/src/main/java/com/wholeseeds/mindle/common/repository/JpaBaseRepository.java
@@ -1,0 +1,4 @@
+package com.wholeseeds.mindle.common.repository;
+
+public class JpaBaseRepository {
+}

--- a/src/main/java/com/wholeseeds/mindle/common/repository/JpaBaseRepositoryImpl.java
+++ b/src/main/java/com/wholeseeds/mindle/common/repository/JpaBaseRepositoryImpl.java
@@ -1,4 +1,53 @@
 package com.wholeseeds.mindle.common.repository;
 
-public class JpaBaseRepositoryImpl {
+import java.io.Serializable;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.support.SimpleJpaRepository;
+
+import com.querydsl.core.types.EntityPath;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.DateTimePath;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.wholeseeds.mindle.common.entity.BaseEntity;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+public class JpaBaseRepositoryImpl<T extends BaseEntity, ID extends Serializable>
+	extends SimpleJpaRepository<T, ID>
+	implements JpaBaseRepository<T, ID> {
+
+	@PersistenceContext
+	private final EntityManager em;
+
+	private final JPAQueryFactory queryFactory;
+	private final EntityPath<T> entityPath;
+	private final NumberPath<Long> idPath;
+	private final DateTimePath<?> deletedAtPath;
+
+	public JpaBaseRepositoryImpl(Class<T> domainClass, EntityManager em, EntityPath<T> entityPath,
+		NumberPath<Long> idPath, DateTimePath<?> deletedAtPath) {
+		super(domainClass, em);
+		this.em = em;
+		this.queryFactory = new JPAQueryFactory(em);
+		this.entityPath = entityPath;
+		this.idPath = idPath;
+		this.deletedAtPath = deletedAtPath;
+	}
+
+	@Override
+	public Optional<T> findByIdNotDeleted(ID id) {
+		BooleanExpression condition = idPath.eq((Long)id).and(deletedAtPath.isNull());
+		return Optional.ofNullable(queryFactory.selectFrom(entityPath).where(condition).fetchOne());
+	}
+
+	@Override
+	public List<T> findAllNotDeleted() {
+		return queryFactory.selectFrom(entityPath)
+			.where(deletedAtPath.isNull())
+			.fetch();
+	}
 }

--- a/src/main/java/com/wholeseeds/mindle/common/repository/JpaBaseRepositoryImpl.java
+++ b/src/main/java/com/wholeseeds/mindle/common/repository/JpaBaseRepositoryImpl.java
@@ -1,0 +1,4 @@
+package com.wholeseeds.mindle.common.repository;
+
+public class JpaBaseRepositoryImpl {
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/auth/entity/MemberProvider.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/auth/entity/MemberProvider.java
@@ -1,7 +1,6 @@
 package com.wholeseeds.mindle.domain.auth.entity;
 
-import java.time.LocalDateTime;
-
+import com.wholeseeds.mindle.common.entity.BaseEntity;
 import com.wholeseeds.mindle.domain.member.entity.Member;
 
 import jakarta.persistence.Column;
@@ -12,7 +11,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -26,7 +24,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class MemberProvider {
+public class MemberProvider extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -42,15 +40,4 @@ public class MemberProvider {
 
 	@Column(name = "user_id")
 	private Long userId;  // firebase user_id (sub)
-
-	@Column(name = "created_at", nullable = false, updatable = false)
-	private LocalDateTime createdAt;
-
-	@Column(name = "deleted_at")
-	private LocalDateTime deletedAt;
-
-	@PrePersist
-	protected void onCreate() {
-		this.createdAt = LocalDateTime.now();
-	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/auth/entity/MemberProvider.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/auth/entity/MemberProvider.java
@@ -1,0 +1,41 @@
+package com.wholeseeds.mindle.domain.auth.entity;
+
+import com.wholeseeds.mindle.domain.member.entity.Member;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "member_provider")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class MemberProvider {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "provider_id", nullable = false)
+	private Provider provider;
+
+	@Column(name = "user_id")
+	private Long userId;  // firebase user_id (sub)
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/auth/entity/MemberProvider.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/auth/entity/MemberProvider.java
@@ -24,6 +24,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class MemberProvider {
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;

--- a/src/main/java/com/wholeseeds/mindle/domain/auth/entity/MemberProvider.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/auth/entity/MemberProvider.java
@@ -6,9 +6,6 @@ import com.wholeseeds.mindle.domain.member.entity.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -25,10 +22,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class MemberProvider extends BaseEntity {
-
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id", nullable = false)

--- a/src/main/java/com/wholeseeds/mindle/domain/auth/entity/MemberProvider.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/auth/entity/MemberProvider.java
@@ -1,5 +1,7 @@
 package com.wholeseeds.mindle.domain.auth.entity;
 
+import java.time.LocalDateTime;
+
 import com.wholeseeds.mindle.domain.member.entity.Member;
 
 import jakarta.persistence.Column;
@@ -10,6 +12,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -39,4 +42,15 @@ public class MemberProvider {
 
 	@Column(name = "user_id")
 	private Long userId;  // firebase user_id (sub)
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
+	@PrePersist
+	protected void onCreate() {
+		this.createdAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/auth/entity/Provider.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/auth/entity/Provider.java
@@ -4,9 +4,6 @@ import com.wholeseeds.mindle.common.entity.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -21,10 +18,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class Provider extends BaseEntity {
-
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
 
 	@Column(length = 100)
 	private String name;

--- a/src/main/java/com/wholeseeds/mindle/domain/auth/entity/Provider.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/auth/entity/Provider.java
@@ -1,10 +1,13 @@
 package com.wholeseeds.mindle.domain.auth.entity;
 
+import java.time.LocalDateTime;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -26,4 +29,15 @@ public class Provider {
 
 	@Column(length = 100)
 	private String name;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
+	@PrePersist
+	protected void onCreate() {
+		this.createdAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/auth/entity/Provider.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/auth/entity/Provider.java
@@ -1,13 +1,12 @@
 package com.wholeseeds.mindle.domain.auth.entity;
 
-import java.time.LocalDateTime;
+import com.wholeseeds.mindle.common.entity.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -21,7 +20,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class Provider {
+public class Provider extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,15 +28,4 @@ public class Provider {
 
 	@Column(length = 100)
 	private String name;
-
-	@Column(name = "created_at", nullable = false, updatable = false)
-	private LocalDateTime createdAt;
-
-	@Column(name = "deleted_at")
-	private LocalDateTime deletedAt;
-
-	@PrePersist
-	protected void onCreate() {
-		this.createdAt = LocalDateTime.now();
-	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/auth/entity/Provider.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/auth/entity/Provider.java
@@ -1,0 +1,29 @@
+package com.wholeseeds.mindle.domain.auth.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "provider")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Provider {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(length = 100)
+	private String name;
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/comment/entity/Comment.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/comment/entity/Comment.java
@@ -11,9 +11,6 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
@@ -32,10 +29,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class Comment extends BaseEntity {
-
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "complaint_id", nullable = false)

--- a/src/main/java/com/wholeseeds/mindle/domain/comment/entity/Comment.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/comment/entity/Comment.java
@@ -1,0 +1,68 @@
+package com.wholeseeds.mindle.domain.comment.entity;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.wholeseeds.mindle.domain.complaint.entity.Complaint;
+import com.wholeseeds.mindle.domain.member.entity.Member;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "comment")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Comment {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "complaint_id", nullable = false)
+	private Complaint complaint;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+
+	// 대댓글용 자기 참조
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "parent_id")
+	private Comment parent;
+
+	@OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+	@OrderBy("createdAt ASC")
+	private List<Comment> children = new ArrayList<>();
+
+	@Column(nullable = false, columnDefinition = "TEXT")
+	private String content;
+
+	@Column(name = "created_at", updatable = false)
+	private LocalDateTime createdAt;
+
+	@PrePersist
+	protected void onCreate() {
+		this.createdAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/comment/entity/Comment.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/comment/entity/Comment.java
@@ -19,6 +19,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderBy;
 import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -58,11 +59,23 @@ public class Comment {
 	@Column(nullable = false, columnDefinition = "TEXT")
 	private String content;
 
-	@Column(name = "created_at", updatable = false)
+	@Column(name = "created_at", nullable = false, updatable = false)
 	private LocalDateTime createdAt;
+
+	@Column(name = "updated_at")
+	private LocalDateTime updatedAt;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
 
 	@PrePersist
 	protected void onCreate() {
 		this.createdAt = LocalDateTime.now();
+		this.updatedAt = this.createdAt;
+	}
+
+	@PreUpdate
+	protected void onUpdate() {
+		this.updatedAt = LocalDateTime.now();
 	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/comment/entity/Comment.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/comment/entity/Comment.java
@@ -1,9 +1,9 @@
 package com.wholeseeds.mindle.domain.comment.entity;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.wholeseeds.mindle.common.entity.BaseEntity;
 import com.wholeseeds.mindle.domain.complaint.entity.Complaint;
 import com.wholeseeds.mindle.domain.member.entity.Member;
 
@@ -18,8 +18,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderBy;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -33,7 +31,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class Comment {
+public class Comment extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -58,24 +56,4 @@ public class Comment {
 
 	@Column(nullable = false, columnDefinition = "TEXT")
 	private String content;
-
-	@Column(name = "created_at", nullable = false, updatable = false)
-	private LocalDateTime createdAt;
-
-	@Column(name = "updated_at")
-	private LocalDateTime updatedAt;
-
-	@Column(name = "deleted_at")
-	private LocalDateTime deletedAt;
-
-	@PrePersist
-	protected void onCreate() {
-		this.createdAt = LocalDateTime.now();
-		this.updatedAt = this.createdAt;
-	}
-
-	@PreUpdate
-	protected void onUpdate() {
-		this.updatedAt = LocalDateTime.now();
-	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/Category.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/Category.java
@@ -19,6 +19,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class Category {
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/Category.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/Category.java
@@ -1,10 +1,13 @@
 package com.wholeseeds.mindle.domain.complaint.entity;
 
+import java.time.LocalDateTime;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -29,4 +32,15 @@ public class Category {
 
 	@Column(columnDefinition = "TEXT")
 	private String description;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
+	@PrePersist
+	protected void onCreate() {
+		this.createdAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/Category.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/Category.java
@@ -1,0 +1,31 @@
+package com.wholeseeds.mindle.domain.complaint.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "category")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Category {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(length = 100, nullable = false)
+	private String name;
+
+	@Column(columnDefinition = "TEXT")
+	private String description;
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/Category.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/Category.java
@@ -1,13 +1,12 @@
 package com.wholeseeds.mindle.domain.complaint.entity;
 
-import java.time.LocalDateTime;
+import com.wholeseeds.mindle.common.entity.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -21,7 +20,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class Category {
+public class Category extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,15 +31,4 @@ public class Category {
 
 	@Column(columnDefinition = "TEXT")
 	private String description;
-
-	@Column(name = "created_at", nullable = false, updatable = false)
-	private LocalDateTime createdAt;
-
-	@Column(name = "deleted_at")
-	private LocalDateTime deletedAt;
-
-	@PrePersist
-	protected void onCreate() {
-		this.createdAt = LocalDateTime.now();
-	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/Category.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/Category.java
@@ -4,9 +4,6 @@ import com.wholeseeds.mindle.common.entity.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -21,10 +18,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class Category extends BaseEntity {
-
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
 
 	@Column(length = 100, nullable = false)
 	private String name;

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/Complaint.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/Complaint.java
@@ -10,9 +10,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -29,9 +26,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class Complaint extends BaseEntity {
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "category_id", nullable = false)

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/Complaint.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/Complaint.java
@@ -1,7 +1,6 @@
 package com.wholeseeds.mindle.domain.complaint.entity;
 
-import java.time.LocalDateTime;
-
+import com.wholeseeds.mindle.common.entity.BaseEntity;
 import com.wholeseeds.mindle.domain.location.entity.Subdistrict;
 import com.wholeseeds.mindle.domain.member.entity.Member;
 import com.wholeseeds.mindle.domain.place.entity.Place;
@@ -16,8 +15,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -31,7 +28,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class Complaint {
+public class Complaint extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -70,26 +67,6 @@ public class Complaint {
 
 	@Column(name = "is_resolved")
 	private Boolean isResolved = false;
-
-	@Column(name = "created_at", nullable = false, updatable = false)
-	private LocalDateTime createdAt;
-
-	@Column(name = "updated_at")
-	private LocalDateTime updatedAt;
-
-	@Column(name = "deleted_at")
-	private LocalDateTime deletedAt;
-
-	@PrePersist
-	protected void onCreate() {
-		this.createdAt = LocalDateTime.now();
-		this.updatedAt = this.createdAt;
-	}
-
-	@PreUpdate
-	protected void onUpdate() {
-		this.updatedAt = LocalDateTime.now();
-	}
 
 	public enum Status {
 		REPORTED,

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/Complaint.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/Complaint.java
@@ -71,11 +71,14 @@ public class Complaint {
 	@Column(name = "is_resolved")
 	private Boolean isResolved = false;
 
-	@Column(name = "created_at", updatable = false)
+	@Column(name = "created_at", nullable = false, updatable = false)
 	private LocalDateTime createdAt;
 
 	@Column(name = "updated_at")
 	private LocalDateTime updatedAt;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
 
 	@PrePersist
 	protected void onCreate() {

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/Complaint.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/Complaint.java
@@ -2,7 +2,9 @@ package com.wholeseeds.mindle.domain.complaint.entity;
 
 import java.time.LocalDateTime;
 
+import com.wholeseeds.mindle.domain.location.entity.Subdistrict;
 import com.wholeseeds.mindle.domain.member.entity.Member;
+import com.wholeseeds.mindle.domain.place.entity.Place;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -42,11 +44,13 @@ public class Complaint {
 	@JoinColumn(name = "member_id", nullable = false)
 	private Member member;
 
-	@Column(name = "place_id")
-	private Long placeId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "subdistrict_id", nullable = false)
+	private Subdistrict subdistrictId;
 
-	@Column(name = "subdistrict_id")
-	private Long subdistrictId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "place_id")
+	private Place placeId;
 
 	@Column(nullable = false)
 	private String title;

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/Complaint.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/Complaint.java
@@ -1,0 +1,92 @@
+package com.wholeseeds.mindle.domain.complaint.entity;
+
+import java.time.LocalDateTime;
+
+import com.wholeseeds.mindle.domain.member.entity.Member;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "complaint")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Complaint {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "category_id", nullable = false)
+	private Category category;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+
+	@Column(name = "place_id")
+	private Long placeId;
+
+	@Column(name = "subdistrict_id")
+	private Long subdistrictId;
+
+	@Column(nullable = false)
+	private String title;
+
+	@Column(nullable = false, columnDefinition = "TEXT")
+	private String content;
+
+	@Column
+	private Double latitude;
+
+	@Column
+	private Double longitude;
+
+	@Enumerated(EnumType.STRING)
+	@Column
+	private Status status = Status.REPORTED;
+
+	@Column(name = "is_resolved")
+	private Boolean isResolved = false;
+
+	@Column(name = "created_at", updatable = false)
+	private LocalDateTime createdAt;
+
+	@Column(name = "updated_at")
+	private LocalDateTime updatedAt;
+
+	@PrePersist
+	protected void onCreate() {
+		this.createdAt = LocalDateTime.now();
+		this.updatedAt = this.createdAt;
+	}
+
+	@PreUpdate
+	protected void onUpdate() {
+		this.updatedAt = LocalDateTime.now();
+	}
+
+	public enum Status {
+		REPORTED,
+		IN_PROGRESS,
+		RESOLVED
+	}
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/ComplaintImage.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/ComplaintImage.java
@@ -1,0 +1,47 @@
+package com.wholeseeds.mindle.domain.complaint.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "complaint_image")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ComplaintImage {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "complaint_id", nullable = false)
+	private Complaint complaint;
+
+	@Column(name = "image_url", length = 500, nullable = false)
+	private String imageUrl;
+
+	@Column(name = "uploaded_at", updatable = false)
+	private LocalDateTime uploadedAt;
+
+	@PrePersist
+	protected void onCreate() {
+		this.uploadedAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/ComplaintImage.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/ComplaintImage.java
@@ -5,9 +5,6 @@ import com.wholeseeds.mindle.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -24,10 +21,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class ComplaintImage extends BaseEntity {
-
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "complaint_id", nullable = false)

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/ComplaintImage.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/ComplaintImage.java
@@ -37,11 +37,14 @@ public class ComplaintImage {
 	@Column(name = "image_url", length = 500, nullable = false)
 	private String imageUrl;
 
-	@Column(name = "uploaded_at", updatable = false)
-	private LocalDateTime uploadedAt;
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
 
 	@PrePersist
 	protected void onCreate() {
-		this.uploadedAt = LocalDateTime.now();
+		this.createdAt = LocalDateTime.now();
 	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/ComplaintImage.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/ComplaintImage.java
@@ -1,6 +1,6 @@
 package com.wholeseeds.mindle.domain.complaint.entity;
 
-import java.time.LocalDateTime;
+import com.wholeseeds.mindle.common.entity.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -10,7 +10,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -24,7 +23,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class ComplaintImage {
+public class ComplaintImage extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -36,15 +35,4 @@ public class ComplaintImage {
 
 	@Column(name = "image_url", length = 500, nullable = false)
 	private String imageUrl;
-
-	@Column(name = "created_at", nullable = false, updatable = false)
-	private LocalDateTime createdAt;
-
-	@Column(name = "deleted_at")
-	private LocalDateTime deletedAt;
-
-	@PrePersist
-	protected void onCreate() {
-		this.createdAt = LocalDateTime.now();
-	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/ComplaintReaction.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/ComplaintReaction.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -40,11 +41,23 @@ public class ComplaintReaction {
 	@JoinColumn(name = "complaint_id", nullable = false)
 	private Complaint complaint;
 
-	@Column(name = "created_at", updatable = false)
+	@Column(name = "created_at", nullable = false, updatable = false)
 	private LocalDateTime createdAt;
+
+	@Column(name = "updated_at")
+	private LocalDateTime updatedAt;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
 
 	@PrePersist
 	protected void onCreate() {
 		this.createdAt = LocalDateTime.now();
+		this.updatedAt = this.createdAt;
+	}
+
+	@PreUpdate
+	protected void onUpdate() {
+		this.updatedAt = LocalDateTime.now();
 	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/ComplaintReaction.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/ComplaintReaction.java
@@ -1,10 +1,8 @@
 package com.wholeseeds.mindle.domain.complaint.entity;
 
-import java.time.LocalDateTime;
-
+import com.wholeseeds.mindle.common.entity.BaseEntity;
 import com.wholeseeds.mindle.domain.member.entity.Member;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -12,8 +10,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -27,7 +23,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class ComplaintReaction {
+public class ComplaintReaction extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -40,24 +36,4 @@ public class ComplaintReaction {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "complaint_id", nullable = false)
 	private Complaint complaint;
-
-	@Column(name = "created_at", nullable = false, updatable = false)
-	private LocalDateTime createdAt;
-
-	@Column(name = "updated_at")
-	private LocalDateTime updatedAt;
-
-	@Column(name = "deleted_at")
-	private LocalDateTime deletedAt;
-
-	@PrePersist
-	protected void onCreate() {
-		this.createdAt = LocalDateTime.now();
-		this.updatedAt = this.createdAt;
-	}
-
-	@PreUpdate
-	protected void onUpdate() {
-		this.updatedAt = LocalDateTime.now();
-	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/ComplaintReaction.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/ComplaintReaction.java
@@ -1,0 +1,50 @@
+package com.wholeseeds.mindle.domain.complaint.entity;
+
+import java.time.LocalDateTime;
+
+import com.wholeseeds.mindle.domain.member.entity.Member;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "complaint_reaction")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ComplaintReaction {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "complaint_id", nullable = false)
+	private Complaint complaint;
+
+	@Column(name = "created_at", updatable = false)
+	private LocalDateTime createdAt;
+
+	@PrePersist
+	protected void onCreate() {
+		this.createdAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/ComplaintReaction.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/ComplaintReaction.java
@@ -5,9 +5,6 @@ import com.wholeseeds.mindle.domain.member.entity.Member;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -24,10 +21,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class ComplaintReaction extends BaseEntity {
-
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id", nullable = false)

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/ComplaintReport.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/ComplaintReport.java
@@ -8,9 +8,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -27,10 +24,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class ComplaintReport extends BaseEntity {
-
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "reporter_member_id", nullable = false)

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/ComplaintReport.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/ComplaintReport.java
@@ -54,11 +54,14 @@ public class ComplaintReport {
 	@Column(nullable = false)
 	private Status status = Status.PENDING;
 
-	@Column(name = "created_at", updatable = false)
+	@Column(name = "created_at", nullable = false, updatable = false)
 	private LocalDateTime createdAt;
 
 	@Column(name = "updated_at")
 	private LocalDateTime updatedAt;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
 
 	@PrePersist
 	protected void onCreate() {

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/ComplaintReport.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/ComplaintReport.java
@@ -1,0 +1,80 @@
+package com.wholeseeds.mindle.domain.complaint.entity;
+
+import java.time.LocalDateTime;
+
+import com.wholeseeds.mindle.domain.member.entity.Member;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "complaint_report")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ComplaintReport {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "reporter_member_id", nullable = false)
+	private Member reporter;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "reported_member_id", nullable = false)
+	private Member reported;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "complaint_id", nullable = false)
+	private Complaint complaint;
+
+	@Column(length = 500, nullable = false)
+	private String reason;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private Status status = Status.PENDING;
+
+	@Column(name = "created_at", updatable = false)
+	private LocalDateTime createdAt;
+
+	@Column(name = "updated_at")
+	private LocalDateTime updatedAt;
+
+	@PrePersist
+	protected void onCreate() {
+		this.createdAt = LocalDateTime.now();
+		this.updatedAt = this.createdAt;
+	}
+
+	@PreUpdate
+	protected void onUpdate() {
+		this.updatedAt = LocalDateTime.now();
+	}
+
+	public enum Status {
+		PENDING,
+		IN_PROGRESS,
+		RESOLVED,
+		CANCELED
+	}
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/ComplaintReport.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/ComplaintReport.java
@@ -1,7 +1,6 @@
 package com.wholeseeds.mindle.domain.complaint.entity;
 
-import java.time.LocalDateTime;
-
+import com.wholeseeds.mindle.common.entity.BaseEntity;
 import com.wholeseeds.mindle.domain.member.entity.Member;
 
 import jakarta.persistence.Column;
@@ -14,8 +13,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -29,7 +26,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class ComplaintReport {
+public class ComplaintReport extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -53,26 +50,6 @@ public class ComplaintReport {
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
 	private Status status = Status.PENDING;
-
-	@Column(name = "created_at", nullable = false, updatable = false)
-	private LocalDateTime createdAt;
-
-	@Column(name = "updated_at")
-	private LocalDateTime updatedAt;
-
-	@Column(name = "deleted_at")
-	private LocalDateTime deletedAt;
-
-	@PrePersist
-	protected void onCreate() {
-		this.createdAt = LocalDateTime.now();
-		this.updatedAt = this.createdAt;
-	}
-
-	@PreUpdate
-	protected void onUpdate() {
-		this.updatedAt = LocalDateTime.now();
-	}
 
 	public enum Status {
 		PENDING,

--- a/src/main/java/com/wholeseeds/mindle/domain/location/entity/City.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/location/entity/City.java
@@ -1,14 +1,12 @@
 package com.wholeseeds.mindle.domain.location.entity;
 
-import java.time.LocalDateTime;
+import com.wholeseeds.mindle.common.entity.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -22,7 +20,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class City {
+public class City extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -30,24 +28,4 @@ public class City {
 
 	@Column(length = 100, nullable = false)
 	private String name;
-
-	@Column(name = "created_at", nullable = false, updatable = false)
-	private LocalDateTime createdAt;
-
-	@Column(name = "updated_at")
-	private LocalDateTime updatedAt;
-
-	@Column(name = "deleted_at")
-	private LocalDateTime deletedAt;
-
-	@PrePersist
-	protected void onCreate() {
-		this.createdAt = LocalDateTime.now();
-		this.updatedAt = this.createdAt;
-	}
-
-	@PreUpdate
-	protected void onUpdate() {
-		this.updatedAt = LocalDateTime.now();
-	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/location/entity/City.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/location/entity/City.java
@@ -1,10 +1,14 @@
 package com.wholeseeds.mindle.domain.location.entity;
 
+import java.time.LocalDateTime;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -26,4 +30,24 @@ public class City {
 
 	@Column(length = 100, nullable = false)
 	private String name;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@Column(name = "updated_at")
+	private LocalDateTime updatedAt;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
+	@PrePersist
+	protected void onCreate() {
+		this.createdAt = LocalDateTime.now();
+		this.updatedAt = this.createdAt;
+	}
+
+	@PreUpdate
+	protected void onUpdate() {
+		this.updatedAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/location/entity/City.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/location/entity/City.java
@@ -4,9 +4,6 @@ import com.wholeseeds.mindle.common.entity.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -21,10 +18,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class City extends BaseEntity {
-
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
 
 	@Column(length = 100, nullable = false)
 	private String name;

--- a/src/main/java/com/wholeseeds/mindle/domain/location/entity/City.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/location/entity/City.java
@@ -19,6 +19,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class City {
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;

--- a/src/main/java/com/wholeseeds/mindle/domain/location/entity/City.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/location/entity/City.java
@@ -1,0 +1,28 @@
+package com.wholeseeds.mindle.domain.location.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "city")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class City {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(length = 100, nullable = false)
+	private String name;
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/location/entity/District.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/location/entity/District.java
@@ -1,0 +1,35 @@
+package com.wholeseeds.mindle.domain.location.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "district")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class District {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "city_id", nullable = false)
+	private City city;
+
+	@Column(length = 100, nullable = false)
+	private String name;
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/location/entity/District.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/location/entity/District.java
@@ -5,9 +5,6 @@ import com.wholeseeds.mindle.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -24,10 +21,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class District extends BaseEntity {
-
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "city_id", nullable = false)

--- a/src/main/java/com/wholeseeds/mindle/domain/location/entity/District.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/location/entity/District.java
@@ -1,6 +1,6 @@
 package com.wholeseeds.mindle.domain.location.entity;
 
-import java.time.LocalDateTime;
+import com.wholeseeds.mindle.common.entity.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -10,8 +10,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -25,7 +23,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class District {
+public class District extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,24 +35,4 @@ public class District {
 
 	@Column(length = 100, nullable = false)
 	private String name;
-
-	@Column(name = "created_at", nullable = false, updatable = false)
-	private LocalDateTime createdAt;
-
-	@Column(name = "updated_at")
-	private LocalDateTime updatedAt;
-
-	@Column(name = "deleted_at")
-	private LocalDateTime deletedAt;
-
-	@PrePersist
-	protected void onCreate() {
-		this.createdAt = LocalDateTime.now();
-		this.updatedAt = this.createdAt;
-	}
-
-	@PreUpdate
-	protected void onUpdate() {
-		this.updatedAt = LocalDateTime.now();
-	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/location/entity/District.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/location/entity/District.java
@@ -1,5 +1,7 @@
 package com.wholeseeds.mindle.domain.location.entity;
 
+import java.time.LocalDateTime;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -8,6 +10,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -33,4 +37,24 @@ public class District {
 
 	@Column(length = 100, nullable = false)
 	private String name;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@Column(name = "updated_at")
+	private LocalDateTime updatedAt;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
+	@PrePersist
+	protected void onCreate() {
+		this.createdAt = LocalDateTime.now();
+		this.updatedAt = this.createdAt;
+	}
+
+	@PreUpdate
+	protected void onUpdate() {
+		this.updatedAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/location/entity/Subdistrict.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/location/entity/Subdistrict.java
@@ -1,6 +1,6 @@
 package com.wholeseeds.mindle.domain.location.entity;
 
-import java.time.LocalDateTime;
+import com.wholeseeds.mindle.common.entity.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -12,8 +12,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -27,7 +25,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class Subdistrict {
+public class Subdistrict extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -43,26 +41,6 @@ public class Subdistrict {
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
 	private Type type;
-
-	@Column(name = "created_at", nullable = false, updatable = false)
-	private LocalDateTime createdAt;
-
-	@Column(name = "updated_at")
-	private LocalDateTime updatedAt;
-
-	@Column(name = "deleted_at")
-	private LocalDateTime deletedAt;
-
-	@PrePersist
-	protected void onCreate() {
-		this.createdAt = LocalDateTime.now();
-		this.updatedAt = this.createdAt;
-	}
-
-	@PreUpdate
-	protected void onUpdate() {
-		this.updatedAt = LocalDateTime.now();
-	}
 
 	public enum Type {
 		EUP, MYEON, DONG, RI  // 향후 변경 필요

--- a/src/main/java/com/wholeseeds/mindle/domain/location/entity/Subdistrict.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/location/entity/Subdistrict.java
@@ -7,9 +7,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -26,10 +23,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class Subdistrict extends BaseEntity {
-
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "district_id", nullable = false)

--- a/src/main/java/com/wholeseeds/mindle/domain/location/entity/Subdistrict.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/location/entity/Subdistrict.java
@@ -24,6 +24,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class Subdistrict {
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;

--- a/src/main/java/com/wholeseeds/mindle/domain/location/entity/Subdistrict.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/location/entity/Subdistrict.java
@@ -1,0 +1,45 @@
+package com.wholeseeds.mindle.domain.location.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "subdistrict")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Subdistrict {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "district_id", nullable = false)
+	private District district;
+
+	@Column(length = 100, nullable = false)
+	private String name;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private Type type;
+
+	public enum Type {
+		EUP, MYEON, DONG, RI  // 향후 변경 필요
+	}
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/location/entity/Subdistrict.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/location/entity/Subdistrict.java
@@ -1,5 +1,7 @@
 package com.wholeseeds.mindle.domain.location.entity;
 
+import java.time.LocalDateTime;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -10,6 +12,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -39,6 +43,26 @@ public class Subdistrict {
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
 	private Type type;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@Column(name = "updated_at")
+	private LocalDateTime updatedAt;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
+	@PrePersist
+	protected void onCreate() {
+		this.createdAt = LocalDateTime.now();
+		this.updatedAt = this.createdAt;
+	}
+
+	@PreUpdate
+	protected void onUpdate() {
+		this.updatedAt = LocalDateTime.now();
+	}
 
 	public enum Type {
 		EUP, MYEON, DONG, RI  // 향후 변경 필요

--- a/src/main/java/com/wholeseeds/mindle/domain/member/entity/Member.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/member/entity/Member.java
@@ -6,9 +6,6 @@ import com.wholeseeds.mindle.domain.location.entity.Subdistrict;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -25,10 +22,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class Member extends BaseEntity {
-
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "subdistrict_id", nullable = false)

--- a/src/main/java/com/wholeseeds/mindle/domain/member/entity/Member.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/member/entity/Member.java
@@ -35,8 +35,8 @@ public class Member {
 	@Column(nullable = false, length = 50)
 	private String nickname;
 
-	@Column(name = "provider_id", nullable = false)
-	private String providerId;
+	@Column(name = "phone", length = 13)
+	private String phone;
 
 	@Column(name = "notification_push")
 	private Boolean notificationPush = false;

--- a/src/main/java/com/wholeseeds/mindle/domain/member/entity/Member.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/member/entity/Member.java
@@ -52,14 +52,14 @@ public class Member {
 	@Column(name = "contribution_score")
 	private Integer contributionScore = 0;
 
-	@Column(name = "deleted_at")
-	private LocalDateTime deletedAt;
-
 	@Column(name = "created_at", nullable = false, updatable = false)
 	private LocalDateTime createdAt;
 
 	@Column(name = "updated_at")
 	private LocalDateTime updatedAt;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
 
 	@PrePersist
 	protected void onCreate() {

--- a/src/main/java/com/wholeseeds/mindle/domain/member/entity/Member.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/member/entity/Member.java
@@ -1,0 +1,69 @@
+package com.wholeseeds.mindle.domain.member.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "member")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Member {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	// 읍/면/동/리 고유 ID (외래키로 연결될 예정)
+	@Column(name = "subdistrict_id", nullable = false)
+	private Long subdistrictId;
+
+	@Column(nullable = false, length = 50)
+	private String nickname;
+
+	@Column(name = "provider_id", nullable = false)
+	private String providerId;
+
+	@Column(name = "notification_push")
+	private Boolean notificationPush = false;
+
+	@Column(name = "notification_inapp")
+	private Boolean notificationInapp = false;
+
+	@Column(name = "contribution_score")
+	private Integer contributionScore = 0;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@Column(name = "updated_at")
+	private LocalDateTime updatedAt;
+
+	@PrePersist
+	protected void onCreate() {
+		this.createdAt = LocalDateTime.now();
+		this.updatedAt = this.createdAt;
+	}
+
+	@PreUpdate
+	protected void onUpdate() {
+		this.updatedAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/member/entity/Member.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/member/entity/Member.java
@@ -2,11 +2,16 @@ package com.wholeseeds.mindle.domain.member.entity;
 
 import java.time.LocalDateTime;
 
+import com.wholeseeds.mindle.domain.location.entity.Subdistrict;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
@@ -28,9 +33,9 @@ public class Member {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	// 읍/면/동/리 고유 ID (외래키로 연결될 예정)
-	@Column(name = "subdistrict_id", nullable = false)
-	private Long subdistrictId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "subdistrict_id", nullable = false)
+	private Subdistrict subdistrictId;
 
 	@Column(nullable = false, length = 50)
 	private String nickname;

--- a/src/main/java/com/wholeseeds/mindle/domain/member/entity/Member.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/member/entity/Member.java
@@ -1,7 +1,6 @@
 package com.wholeseeds.mindle.domain.member.entity;
 
-import java.time.LocalDateTime;
-
+import com.wholeseeds.mindle.common.entity.BaseEntity;
 import com.wholeseeds.mindle.domain.location.entity.Subdistrict;
 
 import jakarta.persistence.Column;
@@ -12,8 +11,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -27,7 +24,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class Member {
+public class Member extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -51,24 +48,4 @@ public class Member {
 
 	@Column(name = "contribution_score")
 	private Integer contributionScore = 0;
-
-	@Column(name = "created_at", nullable = false, updatable = false)
-	private LocalDateTime createdAt;
-
-	@Column(name = "updated_at")
-	private LocalDateTime updatedAt;
-
-	@Column(name = "deleted_at")
-	private LocalDateTime deletedAt;
-
-	@PrePersist
-	protected void onCreate() {
-		this.createdAt = LocalDateTime.now();
-		this.updatedAt = this.createdAt;
-	}
-
-	@PreUpdate
-	protected void onUpdate() {
-		this.updatedAt = LocalDateTime.now();
-	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/member/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.wholeseeds.mindle.domain.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.wholeseeds.mindle.domain.member.entity.Member;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/member/repository/MemberRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.wholeseeds.mindle.domain.member.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.wholeseeds.mindle.domain.member.entity.Member;
+
+public interface MemberRepositoryCustom {
+	Optional<Member> findByIdNotDeleted(Long id);
+
+	List<Member> findAllNotDeleted();
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/member/repository/MemberRepositoryImpl.java
@@ -1,0 +1,16 @@
+package com.wholeseeds.mindle.domain.member.repository;
+
+import com.wholeseeds.mindle.common.repository.JpaBaseRepositoryImpl;
+import com.wholeseeds.mindle.domain.member.entity.Member;
+import com.wholeseeds.mindle.domain.member.entity.QMember;
+
+import jakarta.persistence.EntityManager;
+
+public class MemberRepositoryImpl extends JpaBaseRepositoryImpl<Member, Long> implements MemberRepositoryCustom {
+
+	private static final QMember member = QMember.member;
+
+	public MemberRepositoryImpl(EntityManager em) {
+		super(Member.class, em, member, member.id, member.deletedAt);
+	}
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/member/service/MemberService.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/member/service/MemberService.java
@@ -1,0 +1,26 @@
+package com.wholeseeds.mindle.domain.member.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.wholeseeds.mindle.domain.member.entity.Member;
+import com.wholeseeds.mindle.domain.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+	private final MemberRepository memberRepository;
+
+	public Member getMember(Long id) {
+		return memberRepository.findByIdNotDeleted(id)
+			.orElseThrow(() -> new IllegalArgumentException("존재하지 않거나 삭제된 회원입니다."));
+	}
+
+	public List<Member> getAllActiveMembers() {
+		return memberRepository.findAllNotDeleted();
+	}
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/place/entity/Place.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/place/entity/Place.java
@@ -6,9 +6,6 @@ import com.wholeseeds.mindle.domain.location.entity.Subdistrict;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -25,10 +22,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class Place extends BaseEntity {
-
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "type_id", nullable = false)

--- a/src/main/java/com/wholeseeds/mindle/domain/place/entity/Place.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/place/entity/Place.java
@@ -1,5 +1,7 @@
 package com.wholeseeds.mindle.domain.place.entity;
 
+import java.time.LocalDateTime;
+
 import com.wholeseeds.mindle.domain.location.entity.Subdistrict;
 
 import jakarta.persistence.Column;
@@ -10,6 +12,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -48,4 +52,24 @@ public class Place {
 
 	@Column
 	private Double longitude;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@Column(name = "updated_at")
+	private LocalDateTime updatedAt;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
+	@PrePersist
+	protected void onCreate() {
+		this.createdAt = LocalDateTime.now();
+		this.updatedAt = this.createdAt;
+	}
+
+	@PreUpdate
+	protected void onUpdate() {
+		this.updatedAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/place/entity/Place.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/place/entity/Place.java
@@ -1,4 +1,6 @@
-package com.wholeseeds.mindle.domain.location.entity;
+package com.wholeseeds.mindle.domain.place.entity;
+
+import com.wholeseeds.mindle.domain.location.entity.Subdistrict;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -16,21 +18,34 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "district")
+@Table(name = "place")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class District {
+public class Place {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "city_id", nullable = false)
-	private City city;
+	@JoinColumn(name = "type_id", nullable = false)
+	private PlaceType type;
 
-	@Column(length = 100, nullable = false)
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "subdistrict_id")
+	private Subdistrict subdistrict;
+
+	@Column(nullable = false)
 	private String name;
+
+	@Column(length = 500)
+	private String description;
+
+	@Column
+	private Double latitude;
+
+	@Column
+	private Double longitude;
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/place/entity/Place.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/place/entity/Place.java
@@ -1,7 +1,6 @@
 package com.wholeseeds.mindle.domain.place.entity;
 
-import java.time.LocalDateTime;
-
+import com.wholeseeds.mindle.common.entity.BaseEntity;
 import com.wholeseeds.mindle.domain.location.entity.Subdistrict;
 
 import jakarta.persistence.Column;
@@ -12,8 +11,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -27,7 +24,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class Place {
+public class Place extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -52,24 +49,4 @@ public class Place {
 
 	@Column
 	private Double longitude;
-
-	@Column(name = "created_at", nullable = false, updatable = false)
-	private LocalDateTime createdAt;
-
-	@Column(name = "updated_at")
-	private LocalDateTime updatedAt;
-
-	@Column(name = "deleted_at")
-	private LocalDateTime deletedAt;
-
-	@PrePersist
-	protected void onCreate() {
-		this.createdAt = LocalDateTime.now();
-		this.updatedAt = this.createdAt;
-	}
-
-	@PreUpdate
-	protected void onUpdate() {
-		this.updatedAt = LocalDateTime.now();
-	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/place/entity/PlaceType.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/place/entity/PlaceType.java
@@ -1,13 +1,10 @@
-package com.wholeseeds.mindle.domain.location.entity;
+package com.wholeseeds.mindle.domain.place.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -16,21 +13,17 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "district")
+@Table(name = "place_type")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class District {
+public class PlaceType {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "city_id", nullable = false)
-	private City city;
-
-	@Column(length = 100, nullable = false)
+	@Column(length = 100)
 	private String name;
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/place/entity/PlaceType.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/place/entity/PlaceType.java
@@ -4,9 +4,6 @@ import com.wholeseeds.mindle.common.entity.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -21,10 +18,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class PlaceType extends BaseEntity {
-
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
 
 	@Column(length = 100)
 	private String name;

--- a/src/main/java/com/wholeseeds/mindle/domain/place/entity/PlaceType.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/place/entity/PlaceType.java
@@ -1,13 +1,12 @@
 package com.wholeseeds.mindle.domain.place.entity;
 
-import java.time.LocalDateTime;
+import com.wholeseeds.mindle.common.entity.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -21,7 +20,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class PlaceType {
+public class PlaceType extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,15 +28,4 @@ public class PlaceType {
 
 	@Column(length = 100)
 	private String name;
-
-	@Column(name = "created_at", nullable = false, updatable = false)
-	private LocalDateTime createdAt;
-
-	@Column(name = "deleted_at")
-	private LocalDateTime deletedAt;
-
-	@PrePersist
-	protected void onCreate() {
-		this.createdAt = LocalDateTime.now();
-	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/place/entity/PlaceType.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/place/entity/PlaceType.java
@@ -1,10 +1,13 @@
 package com.wholeseeds.mindle.domain.place.entity;
 
+import java.time.LocalDateTime;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -26,4 +29,15 @@ public class PlaceType {
 
 	@Column(length = 100)
 	private String name;
+
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
+	@PrePersist
+	protected void onCreate() {
+		this.createdAt = LocalDateTime.now();
+	}
 }


### PR DESCRIPTION
- ERD 기반 초기 엔티티 세팅

  - ERD에서 기획한 테이블 구조를 그대로 가져온 것이므로, 추후 개발 과정에서 수정이 필요할 수 있습니다.

    ```
    [auth]
    - MemberProvider
    - Provider
    
    [comment]
    - Comment
    
    [complaint]
    - Category
    - ComplaintImage
    - ComplaintReaction
    - Complaint
    - ComplaintReport
    
    [location]
    - City
    - District
    - Subdistrict
    
    [member]
    - member
    
    [place]
    - Place
    - PlaceType
    ```

- QueryDSL 의존성 추가 (동적 쿼리 제어용)
- 공통 Entity 및 Repository 클래스(BaseEntity, JpaBaseRepository) 구현