### PR TITLE
[Refactor] #45 DTO 롬복 어노테이션 정리 및 행정구역 상세 조회 API 요청 방식 변경

### DIFF
--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/CommentDto.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/CommentDto.java
@@ -5,14 +5,10 @@ import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.ToString;
 
 @Getter
 @Builder
-@RequiredArgsConstructor
 @AllArgsConstructor
-@ToString
 public class CommentDto {
 	private Long id;
 	private String content;

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/ComplaintDetailWithImagesDto.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/ComplaintDetailWithImagesDto.java
@@ -6,14 +6,10 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.ToString;
 
 @Getter
 @Builder
-@RequiredArgsConstructor
 @AllArgsConstructor
-@ToString
 public class ComplaintDetailWithImagesDto {
 	private Long id;
 	private String title;

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/ReactionDto.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/ReactionDto.java
@@ -3,14 +3,10 @@ package com.wholeseeds.mindle.domain.complaint.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.ToString;
 
 @Getter
 @Builder
-@RequiredArgsConstructor
 @AllArgsConstructor
-@ToString
 public class ReactionDto {
 	private Long reactionCount;
 	private boolean isReacted; // 로그인 사용자의 공감 여부

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/request/CommentRequestDto.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/request/CommentRequestDto.java
@@ -1,19 +1,14 @@
 package com.wholeseeds.mindle.domain.complaint.dto.request;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.NoArgsConstructor;
 
-@Setter
 @Getter
-@Builder
-@RequiredArgsConstructor
+@NoArgsConstructor
 @AllArgsConstructor
-@ToString
 public class CommentRequestDto {
+
 	private Long complaintId;
 	private String cursorCreatedAt;
 	private int pageSize;

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/request/ComplaintListRequestDto.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/request/ComplaintListRequestDto.java
@@ -1,19 +1,14 @@
 package com.wholeseeds.mindle.domain.complaint.dto.request;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.NoArgsConstructor;
 
-@Setter
 @Getter
-@Builder
-@RequiredArgsConstructor
+@NoArgsConstructor
 @AllArgsConstructor
-@ToString
 public class ComplaintListRequestDto {
+
 	private Long cursorComplaintId;
 	private int pageSize;
 	private String cityCode;

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/request/SaveComplaintRequestDto.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/request/SaveComplaintRequestDto.java
@@ -2,17 +2,14 @@ package com.wholeseeds.mindle.domain.complaint.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.ToString;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
-@RequiredArgsConstructor
+@NoArgsConstructor
 @AllArgsConstructor
-@ToString
 public class SaveComplaintRequestDto {
+
 	@NotNull
 	private Long categoryId;
 	private String cityName;

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/response/ComplaintDetailResponseDto.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/response/ComplaintDetailResponseDto.java
@@ -6,15 +6,12 @@ import com.wholeseeds.mindle.domain.complaint.dto.ReactionDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.ToString;
 
 @Getter
 @Builder
-@RequiredArgsConstructor
 @AllArgsConstructor
-@ToString
 public class ComplaintDetailResponseDto {
+
 	ComplaintDetailWithImagesDto complaintDetailWithImagesDto;
 	ReactionDto reactionDto;
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/response/ComplaintListResponseDto.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/response/ComplaintListResponseDto.java
@@ -5,15 +5,12 @@ import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.ToString;
 
 @Getter
 @Builder
-@RequiredArgsConstructor
 @AllArgsConstructor
-@ToString
 public class ComplaintListResponseDto {
+
 	private Long complaintId;
 	private String title;
 	private String content;

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/response/SaveComplaintResponseDto.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/response/SaveComplaintResponseDto.java
@@ -5,15 +5,12 @@ import com.wholeseeds.mindle.domain.complaint.entity.Complaint;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.ToString;
 
 @Getter
 @Builder
-@RequiredArgsConstructor
 @AllArgsConstructor
-@ToString
 public class SaveComplaintResponseDto {
+
 	private Long id;
 	private Long categoryId;
 	private Long memberId;

--- a/src/main/java/com/wholeseeds/mindle/domain/member/dto/request/UpdateNicknameRequestDto.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/member/dto/request/UpdateNicknameRequestDto.java
@@ -2,11 +2,13 @@ package com.wholeseeds.mindle.domain.member.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class UpdateNicknameRequestDto {
 
 	@NotBlank(message = "닉네임은 필수입니다.")

--- a/src/main/java/com/wholeseeds/mindle/domain/member/dto/request/UpdateNotificationSettingRequestDto.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/member/dto/request/UpdateNotificationSettingRequestDto.java
@@ -3,9 +3,13 @@ package com.wholeseeds.mindle.domain.member.dto.request;
 import com.wholeseeds.mindle.domain.member.enums.NotificationType;
 
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class UpdateNotificationSettingRequestDto {
 
 	@NotNull

--- a/src/main/java/com/wholeseeds/mindle/domain/member/dto/request/UpdateSubdistrictRequestDto.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/member/dto/request/UpdateSubdistrictRequestDto.java
@@ -1,11 +1,13 @@
 package com.wholeseeds.mindle.domain.member.dto.request;
 
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class UpdateSubdistrictRequestDto {
 
 	@NotNull(message = "subdistrictCode는 필수입니다.")

--- a/src/main/java/com/wholeseeds/mindle/domain/member/dto/response/MemberResponseDto.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/member/dto/response/MemberResponseDto.java
@@ -9,8 +9,8 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 @Builder
+@AllArgsConstructor
 public class MemberResponseDto {
 
 	private Long id;

--- a/src/main/java/com/wholeseeds/mindle/domain/region/controller/RegionController.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/region/controller/RegionController.java
@@ -22,7 +22,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
-@Tag(name = "행정구역", description = "행정구역 조회 API (시/군, 구, 읍/면/동)")
+@Tag(name = "행정구역")
 @RestController
 @RequestMapping("/api/region")
 @RequiredArgsConstructor

--- a/src/main/java/com/wholeseeds/mindle/domain/region/controller/RegionController.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/region/controller/RegionController.java
@@ -4,18 +4,18 @@ import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.wholeseeds.mindle.common.util.ResponseTemplate;
+import com.wholeseeds.mindle.domain.region.dto.request.RegionDetailRequestDto;
 import com.wholeseeds.mindle.domain.region.dto.response.RegionDetailResponseDto;
 import com.wholeseeds.mindle.domain.region.enums.RegionType;
 import com.wholeseeds.mindle.domain.region.service.RegionService;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -34,7 +34,7 @@ public class RegionController {
 	/**
 	 * 행정구역 상세 조회 및 하위 목록 조회
 	 */
-	@GetMapping("/detail")
+	@PostMapping("/detail")
 	@Operation(
 		summary = "행정구역 상세 및 하위 목록 조회",
 		description = """
@@ -48,10 +48,11 @@ public class RegionController {
 		- districts: 하위 구 목록 (city인 경우에만 포함, 이외의 경우는 null)
 		- subdistricts: 하위 읍/면/동 목록 (city, district인 경우 포함, 이외의 경우는 null)
 		""",
-		parameters = {
-			@Parameter(name = "regionType", description = "행정구역 종류 (city, district, subdistrict)", required = true),
-			@Parameter(name = "code", description = "행정구역 코드", required = true)
-		}
+		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+			description = "행정구역 상세 조회 요청",
+			required = true,
+			content = @Content(schema = @Schema(implementation = RegionDetailRequestDto.class))
+		)
 	)
 	@ApiResponse(
 		responseCode = "200",
@@ -59,11 +60,10 @@ public class RegionController {
 		content = @Content(schema = @Schema(implementation = RegionDetailResponseDto.class))
 	)
 	public ResponseEntity<Map<String, Object>> getRegionDetail(
-		@RequestParam String regionType,
-		@RequestParam String code
+		@RequestBody RegionDetailRequestDto request
 	) {
-		RegionType type = RegionType.from(regionType);
-		RegionDetailResponseDto<?> response = regionService.getRegionDetail(type, code);
+		RegionType type = RegionType.from(request.getRegionType());
+		RegionDetailResponseDto<?> response = regionService.getRegionDetail(type, request.getCode());
 		return responseTemplate.success(response, HttpStatus.OK);
 	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/region/dto/request/RegionDetailRequestDto.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/region/dto/request/RegionDetailRequestDto.java
@@ -1,0 +1,19 @@
+package com.wholeseeds.mindle.domain.region.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "행정구역 상세 조회 요청 DTO")
+public class RegionDetailRequestDto {
+
+	@Schema(description = "행정구역 종류", example = "city", allowableValues = {"city", "district", "subdistrict"})
+	private String regionType;
+
+	@Schema(description = "행정구역 코드", example = "11000")
+	private String code;
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

* [x] #45 

## 📝 작업 내용

* [x] 불필요한 Lombok 어노테이션(`@RequiredArgsConstructor`, `@ToString`, `@Builder` 등) 제거 및 DTO 클래스 구조 단순화
* [x] 일부 DTO에 `@NoArgsConstructor`, `@AllArgsConstructor` 추가하여 직렬화/역직렬화 및 테스트 편의성 향상
* [x] `RegionController`의 `/detail` 엔드포인트 요청 방식을 **GET + @RequestParam → POST + @RequestBody**로 변경
* [x] ⭐️ `RegionDetailRequestDto` 신규 추가 (regionType, code를 포함한 요청 DTO)
* [x] Swagger 문서에서 RequestParam 기반 → RequestBody 기반 스펙으로 수정 (`@RequestBody` + `@Schema`)

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

* `/api/region/detail` API의 요청 방식을 변경했으므로, 프론트엔드 연동 코드가 정상 동작하는지 점검 부탁드립니다.

## 🔮 향후 개발 시 유의점

* `RegionDetailRequestDto`는 앞으로 행정구역 상세 조회 외에도 유사한 요청 구조가 필요한 경우 재사용하실 수 있습니다.

  ```java
  // 예시: RegionDetailRequestDto 생성 및 요청
  RegionDetailRequestDto request = new RegionDetailRequestDto("city", "11000");
  RegionType type = RegionType.from(request.getRegionType());
  RegionDetailResponseDto<?> dto = regionService.getRegionDetail(type, request.getCode());
  ```
* `/api/region/detail`가 POST 방식으로 변경되었으므로, API 호출 시 JSON body를 포함해야 합니다.
* 향후 개발 시 DTO에 불필요한 Lombok 어노테이션을 추가하지 않는 것을 권장합니다.