### PR TITLE
[Feat] #32 민원 수정/삭제 API 및 장소 업서트 로직 추가

### DIFF
--- a/src/main/java/com/wholeseeds/mindle/common/response/ErrorCode.java
+++ b/src/main/java/com/wholeseeds/mindle/common/response/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
 	PLACE_NOT_FOUND(404, "해당 장소를 찾을 수 없습니다"),
 	IMAGE_UPLOAD_LIMIT_EXCEEDED(400, "이미지는 최대 3장까지 업로드 가능합니다"),
 	COMPLAINT_NOT_FOUND(404, "해당 민원을 찾을 수 없습니다"),
+	NOT_COMPLAINT_OWNER(403, "해당 민원의 작성자가 아닙니다"),
 
 	// region
 	CITY_NOT_FOUND(404, "해당 (시/군)를 찾을 수 없습니다"),

--- a/src/main/java/com/wholeseeds/mindle/common/response/ErrorCode.java
+++ b/src/main/java/com/wholeseeds/mindle/common/response/ErrorCode.java
@@ -30,17 +30,21 @@ public enum ErrorCode {
 
 	// complaint
 	CATEGORY_NOT_FOUND(404, "해당 카테고리를 찾을 수 없습니다"),
-	PLACE_NOT_FOUND(404, "해당 장소를 찾을 수 없습니다"),
 	IMAGE_UPLOAD_LIMIT_EXCEEDED(400, "이미지는 최대 3장까지 업로드 가능합니다"),
 	COMPLAINT_NOT_FOUND(404, "해당 민원을 찾을 수 없습니다"),
 	NOT_COMPLAINT_OWNER(403, "해당 민원의 작성자가 아닙니다"),
 
-	// region
+	// region,
 	CITY_NOT_FOUND(404, "해당 (시/군)를 찾을 수 없습니다"),
 	DISTRICT_NOT_FOUND(404, "해당 (구)를 찾을 수 없습니다"),
 	SUBDISTRICT_NOT_FOUND(404, "해당 (읍/면/동)를 찾을 수 없습니다"),
 	INVALID_SUBDISTRICT_REFERENCE(400, "Subdistrict는 하나의 City 또는 District만 참조해야 합니다."),
 	INVALID_REGION_TYPE(400, "올바르지 않은 regionType 값입니다. (city, district, subdistrict 중 하나여야 합니다)"),
+
+	// place
+	PLACE_NOT_FOUND(404, "해당 장소를 찾을 수 없습니다"),
+	PLACE_TYPE_REQUIRED(400, "신규 장소 생성을 위해 placeType이 필요합니다."),
+	PLACE_NAME_REQUIRED(400, "신규 장소 생성을 위해 placeName이 필요합니다."),
 
 	// NCP
 	NCP_FILE_UPLOAD_FAILED(500, "NCP 에 파일 저장 중 오류가 발생했습니다"),

--- a/src/main/java/com/wholeseeds/mindle/common/util/ObjectUtils.java
+++ b/src/main/java/com/wholeseeds/mindle/common/util/ObjectUtils.java
@@ -34,4 +34,11 @@ public class ObjectUtils {
 		}
 		return LocalDateTime.parse(dateTimeString);
 	}
+
+	/**
+	 * null/빈문자열을 제외한 텍스트 여부를 확인
+	 */
+	public boolean hasText(String s) {
+		return s != null && !s.isBlank();
+	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/controller/ComplaintController.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/controller/ComplaintController.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -162,5 +163,26 @@ public class ComplaintController {
 		SaveComplaintResponseDto responseDto =
 			complaintService.handleUpdateComplaint(memberId, complaintId, requestDto, imageList);
 		return responseTemplate.success(responseDto, HttpStatus.OK);
+	}
+
+	/**
+	 * 민원 삭제 API
+	 */
+	@Operation(
+		summary = "민원 삭제",
+		description = "민원을 soft delete 합니다. 작성자 본인만 삭제할 수 있습니다."
+	)
+	@ApiResponse(
+		responseCode = "204",
+		description = "민원 삭제 성공"
+	)
+	@DeleteMapping("/{complaintId}")
+	@RequireAuth
+	public ResponseEntity<Map<String, Object>> deleteComplaint(
+		@PathVariable Long complaintId,
+		@Parameter(hidden = true) @CurrentMemberId Long memberId
+	) {
+		complaintService.handleDeleteComplaint(memberId, complaintId);
+		return responseTemplate.success(null, HttpStatus.OK);
 	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/controller/ComplaintController.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/controller/ComplaintController.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,6 +24,7 @@ import com.wholeseeds.mindle.domain.complaint.dto.CommentDto;
 import com.wholeseeds.mindle.domain.complaint.dto.request.CommentRequestDto;
 import com.wholeseeds.mindle.domain.complaint.dto.request.ComplaintListRequestDto;
 import com.wholeseeds.mindle.domain.complaint.dto.request.SaveComplaintRequestDto;
+import com.wholeseeds.mindle.domain.complaint.dto.request.UpdateComplaintRequestDto;
 import com.wholeseeds.mindle.domain.complaint.dto.response.ComplaintDetailResponseDto;
 import com.wholeseeds.mindle.domain.complaint.dto.response.ComplaintListResponseDto;
 import com.wholeseeds.mindle.domain.complaint.dto.response.SaveComplaintResponseDto;
@@ -135,5 +137,30 @@ public class ComplaintController {
 	public ResponseEntity<Map<String, Object>> getComplaintList(@ModelAttribute ComplaintListRequestDto requestDto) {
 		List<ComplaintListResponseDto> responseDtos = complaintService.getComplaintListResponse(requestDto);
 		return responseTemplate.success(responseDtos, HttpStatus.OK);
+	}
+
+	/**
+	 * 민원 수정 API
+	 */
+	@Operation(
+		summary = "민원 수정",
+		description = "민원 일부 필드를 수정합니다. replaceImages=true일 경우 기존 이미지를 모두 교체합니다."
+	)
+	@ApiResponse(
+		responseCode = "200",
+		description = "민원 수정 성공",
+		content = @Content(schema = @Schema(implementation = SaveComplaintResponseDto.class))
+	)
+	@PatchMapping(value = "/{complaintId}", consumes = MULTIPART_FORM_DATA_VALUE)
+	@RequireAuth
+	public ResponseEntity<Map<String, Object>> updateComplaint(
+		@PathVariable Long complaintId,
+		@Parameter(hidden = true) @CurrentMemberId Long memberId,
+		@RequestPart("meta") UpdateComplaintRequestDto requestDto,
+		@RequestPart(value = "files", required = false) List<MultipartFile> imageList
+	) {
+		SaveComplaintResponseDto responseDto =
+			complaintService.handleUpdateComplaint(memberId, complaintId, requestDto, imageList);
+		return responseTemplate.success(responseDto, HttpStatus.OK);
 	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/request/SaveComplaintRequestDto.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/request/SaveComplaintRequestDto.java
@@ -18,7 +18,7 @@ public class SaveComplaintRequestDto {
 	private String title;
 	@NotNull
 	private String content;
-	private double latitude;
-	private double longitude;
+	private Double latitude;
+	private Double longitude;
 	// private String photoUrl; // TODO 이미지 파일
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/request/SaveComplaintRequestDto.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/request/SaveComplaintRequestDto.java
@@ -12,13 +12,26 @@ public class SaveComplaintRequestDto {
 
 	@NotNull
 	private Long categoryId;
+
 	private String subdistrictCode;
+
 	private String placeId;
+
+	private String placeType;
+
+	private String placeName;
+
+	private String placeDescription;
+
 	@NotNull
 	private String title;
+
 	@NotNull
 	private String content;
+
 	private Double latitude;
+
 	private Double longitude;
+
 	// private String photoUrl; // TODO 이미지 파일
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/request/UpdateComplaintRequestDto.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/request/UpdateComplaintRequestDto.java
@@ -1,0 +1,19 @@
+package com.wholeseeds.mindle.domain.complaint.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateComplaintRequestDto {
+	private Long categoryId;
+	private String subdistrictCode;
+	private String placeId;
+	private String title;
+	private String content;
+	private Double latitude;
+	private Double longitude;
+	private Boolean replaceImages;
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/request/UpdateComplaintRequestDto.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/request/UpdateComplaintRequestDto.java
@@ -8,12 +8,28 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class UpdateComplaintRequestDto {
+
 	private Long categoryId;
+
 	private String subdistrictCode;
+
 	private String placeId;
+
+	private String placeType;
+
+	private String placeName;
+
+	private String placeDescription;
+
 	private String title;
+
 	private String content;
+
 	private Double latitude;
+
 	private Double longitude;
+
+	private Boolean clearPlace;
+
 	private Boolean replaceImages;
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/response/SaveComplaintResponseDto.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/response/SaveComplaintResponseDto.java
@@ -1,6 +1,7 @@
 package com.wholeseeds.mindle.domain.complaint.dto.response;
 
 import com.wholeseeds.mindle.domain.complaint.entity.Complaint;
+import com.wholeseeds.mindle.domain.place.dto.PlaceDto;
 import com.wholeseeds.mindle.domain.region.dto.SubdistrictDto;
 
 import lombok.AllArgsConstructor;
@@ -16,7 +17,7 @@ public class SaveComplaintResponseDto {
 	private Long categoryId;
 	private Long memberId;
 	private SubdistrictDto subdistrictDto;
-	private Long placeId;
+	private PlaceDto placeDto;
 	private String title;
 	private String content;
 	private Double latitude;

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/Complaint.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/Complaint.java
@@ -79,4 +79,29 @@ public class Complaint extends BaseEntity {
 			isResolved = false;
 		}
 	}
+
+	public void changeCategory(Category category) {
+		this.category = category;
+	}
+
+	public void changeSubdistrict(Subdistrict subdistrict) {
+		this.subdistrict = subdistrict;
+	}
+
+	public void changePlace(Place place) {
+		this.place = place;
+	}
+
+	public void changeTitle(String title) {
+		this.title = title;
+	}
+
+	public void changeContent(String content) {
+		this.content = content;
+	}
+
+	public void changeLatLng(Double lat, Double lng) {
+		this.latitude = lat;
+		this.longitude = lng;
+	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/exception/NotComplaintOwnerException.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/exception/NotComplaintOwnerException.java
@@ -1,0 +1,10 @@
+package com.wholeseeds.mindle.domain.complaint.exception;
+
+import com.wholeseeds.mindle.common.exception.BusinessException;
+import com.wholeseeds.mindle.common.response.ErrorCode;
+
+public class NotComplaintOwnerException extends BusinessException {
+	public NotComplaintOwnerException() {
+		super(ErrorCode.NOT_COMPLAINT_OWNER);
+	}
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/mapper/ComplaintMapper.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/mapper/ComplaintMapper.java
@@ -9,14 +9,15 @@ import org.mapstruct.NullValuePropertyMappingStrategy;
 import com.wholeseeds.mindle.domain.complaint.dto.request.UpdateComplaintRequestDto;
 import com.wholeseeds.mindle.domain.complaint.dto.response.SaveComplaintResponseDto;
 import com.wholeseeds.mindle.domain.complaint.entity.Complaint;
+import com.wholeseeds.mindle.domain.place.mapper.PlaceMapper;
 import com.wholeseeds.mindle.domain.region.mapper.RegionMapper;
 
-@Mapper(componentModel = "spring", uses = {RegionMapper.class})
+@Mapper(componentModel = "spring", uses = {RegionMapper.class, PlaceMapper.class})
 public interface ComplaintMapper {
 	@Mapping(target = "categoryId", source = "category.id")
 	@Mapping(target = "memberId", source = "member.id")
 	@Mapping(target = "subdistrictDto", source = "subdistrict")
-	@Mapping(target = "placeId", source = "place.id")
+	@Mapping(target = "placeDto", source = "place")
 	SaveComplaintResponseDto toSaveComplaintResponseDto(Complaint complaint);
 
 	@BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/mapper/ComplaintMapper.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/mapper/ComplaintMapper.java
@@ -1,8 +1,12 @@
 package com.wholeseeds.mindle.domain.complaint.mapper;
 
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
 
+import com.wholeseeds.mindle.domain.complaint.dto.request.UpdateComplaintRequestDto;
 import com.wholeseeds.mindle.domain.complaint.dto.response.SaveComplaintResponseDto;
 import com.wholeseeds.mindle.domain.complaint.entity.Complaint;
 import com.wholeseeds.mindle.domain.region.mapper.RegionMapper;
@@ -14,4 +18,7 @@ public interface ComplaintMapper {
 	@Mapping(target = "subdistrictDto", source = "subdistrict")
 	@Mapping(target = "placeId", source = "place.id")
 	SaveComplaintResponseDto toSaveComplaintResponseDto(Complaint complaint);
+
+	@BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+	void applyScalarPatch(UpdateComplaintRequestDto dto, @MappingTarget Complaint target);
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/repository/impl/ComplaintRepositoryImpl.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/repository/impl/ComplaintRepositoryImpl.java
@@ -66,7 +66,8 @@ public class ComplaintRepositoryImpl extends JpaBaseRepositoryImpl<Complaint, Lo
 		List<String> imageUrls = queryFactory
 			.select(I.imageUrl)
 			.from(I)
-			.where(I.complaint.id.eq(complaintId))
+			.where(I.complaint.id.eq(complaintId)
+				.and(I.deletedAt.isNull()))
 			.fetch();
 
 		// 지역 정보 DTO 생성

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/service/ComplaintImageService.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/service/ComplaintImageService.java
@@ -82,6 +82,19 @@ public class ComplaintImageService {
 		saveComplaintImages(complaint, newImages);
 	}
 
+	/** 모든 활성 이미지를 soft delete 처리한다. */
+	@Transactional
+	public void softDeleteAllForComplaint(Complaint complaint) {
+		List<ComplaintImage> all = complaintImageRepository.findAllByComplaintId(complaint.getId());
+		for (ComplaintImage img : all) {
+			if (!img.isDeleted()) {
+				img.softDelete();
+				complaintImageRepository.save(img);
+				// TODO: 필요 시 NCP 실제 파일 삭제 호출
+			}
+		}
+	}
+
 	private List<ComplaintImage> findActiveImages(Long complaintId) {
 		return complaintImageRepository.findAllByComplaintId(complaintId).stream()
 			.filter(img -> !img.isDeleted())

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/service/ComplaintImageService.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/service/ComplaintImageService.java
@@ -9,6 +9,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.wholeseeds.mindle.common.util.ObjectUtils;
 import com.wholeseeds.mindle.domain.complaint.entity.Complaint;
 import com.wholeseeds.mindle.domain.complaint.entity.ComplaintImage;
+import com.wholeseeds.mindle.domain.complaint.exception.ImageUploadLimitExceeded;
 import com.wholeseeds.mindle.domain.complaint.repository.ComplaintImageRepository;
 import com.wholeseeds.mindle.infra.service.NcpObjectStorageService;
 
@@ -19,17 +20,18 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class ComplaintImageService {
+
 	private final ComplaintImageRepository complaintImageRepository;
 	private final NcpObjectStorageService ncpObjectStorageService;
 
 	private static final String COMPLAINT_IMAGE_FOLDER = "complaint";
+	private static final int MAX_IMAGES = 3;
 
 	/**
 	 * 민원 이미지 저장
 	 * @param complaint 민원 객체
 	 * @param imageList 이미지 파일 목록
 	 */
-	@Transactional
 	public void saveComplaintImages(Complaint complaint, List<MultipartFile> imageList) {
 		if (ObjectUtils.objectIsNullOrEmpty(imageList)) {
 			return;
@@ -37,11 +39,52 @@ public class ComplaintImageService {
 
 		for (MultipartFile imageFile : imageList) {
 			String imageUrl = ncpObjectStorageService.uploadFile(COMPLAINT_IMAGE_FOLDER, imageFile);
+
 			ComplaintImage complaintImage = ComplaintImage.builder()
 				.complaint(complaint)
 				.imageUrl(imageUrl)
 				.build();
+
 			complaintImageRepository.save(complaintImage);
 		}
+	}
+
+
+	@Transactional
+	public void replaceImages(Complaint complaint, List<MultipartFile> newImages) {
+		List<ComplaintImage> active = findActiveImages(complaint.getId());
+		for (ComplaintImage img : active) {
+			img.softDelete();
+			complaintImageRepository.save(img);
+			// TODO: 필요 시 NCP 실제 파일 삭제 호출
+		}
+
+		if (!ObjectUtils.objectIsNullOrEmpty(newImages)) {
+			if (newImages.size() > MAX_IMAGES) {
+				throw new ImageUploadLimitExceeded();
+			}
+			saveComplaintImages(complaint, newImages);
+		}
+	}
+
+	/** 추가: 기존 활성 + 신규 ≤ MAX 검증 후 저장 */
+	@Transactional
+	public void appendImages(Complaint complaint, List<MultipartFile> newImages) {
+		if (ObjectUtils.objectIsNullOrEmpty(newImages)) {
+			return;
+		}
+
+		int activeCount = findActiveImages(complaint.getId()).size();
+		if (activeCount + newImages.size() > MAX_IMAGES) {
+			throw new ImageUploadLimitExceeded();
+		}
+
+		saveComplaintImages(complaint, newImages);
+	}
+
+	private List<ComplaintImage> findActiveImages(Long complaintId) {
+		return complaintImageRepository.findAllByComplaintId(complaintId).stream()
+			.filter(img -> !img.isDeleted())
+			.toList();
 	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/place/dto/command/PlaceUpsertCmd.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/place/dto/command/PlaceUpsertCmd.java
@@ -1,0 +1,16 @@
+package com.wholeseeds.mindle.domain.place.dto.command;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PlaceUpsertCmd {
+	private final String placeId;
+	private final String placeTypeName;
+	private final String placeName;
+	private final String description;
+	private final Double latitude;
+	private final Double longitude;
+	private final String subdistrictCode;
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/place/entity/Place.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/place/entity/Place.java
@@ -45,4 +45,21 @@ public class Place extends BaseEntity {
 
 	@Column
 	private Double longitude;
+
+	public void changeName(String name) {
+		this.name = name;
+	}
+
+	public void changeDescription(String description) {
+		this.description = description;
+	}
+
+	public void changeLatLng(Double latitude, Double longitude) {
+		this.latitude = latitude;
+		this.longitude = longitude;
+	}
+
+	public void changeSubdistrict(Subdistrict subdistrict) {
+		this.subdistrict = subdistrict;
+	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/place/entity/PlaceType.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/place/entity/PlaceType.java
@@ -19,6 +19,6 @@ import lombok.NoArgsConstructor;
 @Builder
 public class PlaceType extends BaseEntity {
 
-	@Column(length = 100)
+	@Column(length = 100, nullable = false, unique = true)
 	private String name;
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/place/exception/PlaceNameRequiredException.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/place/exception/PlaceNameRequiredException.java
@@ -1,0 +1,10 @@
+package com.wholeseeds.mindle.domain.place.exception;
+
+import com.wholeseeds.mindle.common.exception.BusinessException;
+import com.wholeseeds.mindle.common.response.ErrorCode;
+
+public class PlaceNameRequiredException extends BusinessException {
+	public PlaceNameRequiredException() {
+		super(ErrorCode.PLACE_NAME_REQUIRED);
+	}
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/place/exception/PlaceTypeRequiredException.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/place/exception/PlaceTypeRequiredException.java
@@ -1,0 +1,10 @@
+package com.wholeseeds.mindle.domain.place.exception;
+
+import com.wholeseeds.mindle.common.exception.BusinessException;
+import com.wholeseeds.mindle.common.response.ErrorCode;
+
+public class PlaceTypeRequiredException extends BusinessException {
+	public PlaceTypeRequiredException() {
+		super(ErrorCode.PLACE_TYPE_REQUIRED);
+	}
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/place/repository/PlaceRepository.java
@@ -7,4 +7,6 @@ import com.wholeseeds.mindle.domain.place.entity.Place;
 
 public interface PlaceRepository extends JpaBaseRepository<Place, Long> {
 	Optional<Place> findByPlaceId(String placeId);
+
+	Optional<Place> findByPlaceIdAndDeletedAtIsNull(String placeId);
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/place/repository/PlaceTypeRepository.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/place/repository/PlaceTypeRepository.java
@@ -1,0 +1,12 @@
+package com.wholeseeds.mindle.domain.place.repository;
+
+import java.util.Optional;
+
+import com.wholeseeds.mindle.common.repository.JpaBaseRepository;
+import com.wholeseeds.mindle.domain.place.entity.PlaceType;
+
+public interface PlaceTypeRepository extends JpaBaseRepository<PlaceType, Long> {
+	Optional<PlaceType> findByName(String name);
+
+	Optional<PlaceType> findByNameAndDeletedAtIsNull(String name);
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/place/repository/custom/PlaceTypeRepositoryCustom.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/place/repository/custom/PlaceTypeRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.wholeseeds.mindle.domain.place.repository.custom;
+
+public interface PlaceTypeRepositoryCustom {
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/place/repository/impl/PlaceTypeRepositoryImpl.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/place/repository/impl/PlaceTypeRepositoryImpl.java
@@ -1,0 +1,17 @@
+package com.wholeseeds.mindle.domain.place.repository.impl;
+
+import com.wholeseeds.mindle.common.repository.JpaBaseRepositoryImpl;
+import com.wholeseeds.mindle.domain.place.entity.PlaceType;
+import com.wholeseeds.mindle.domain.place.entity.QPlaceType;
+import com.wholeseeds.mindle.domain.place.repository.custom.PlaceTypeRepositoryCustom;
+
+import jakarta.persistence.EntityManager;
+
+public class PlaceTypeRepositoryImpl extends JpaBaseRepositoryImpl<PlaceType, Long> implements
+	PlaceTypeRepositoryCustom {
+	private static final QPlaceType PT = QPlaceType.placeType;
+
+	public PlaceTypeRepositoryImpl(EntityManager em) {
+		super(PlaceType.class, em, PT, PT.id, PT.deletedAt);
+	}
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/place/service/PlaceService.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/place/service/PlaceService.java
@@ -1,11 +1,22 @@
 package com.wholeseeds.mindle.domain.place.service;
 
+import java.util.Optional;
+
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
+import com.wholeseeds.mindle.domain.place.dto.command.PlaceUpsertCmd;
 import com.wholeseeds.mindle.domain.place.entity.Place;
+import com.wholeseeds.mindle.domain.place.entity.PlaceType;
+import com.wholeseeds.mindle.domain.place.exception.PlaceNameRequiredException;
 import com.wholeseeds.mindle.domain.place.exception.PlaceNotFoundException;
+import com.wholeseeds.mindle.domain.place.exception.PlaceTypeRequiredException;
 import com.wholeseeds.mindle.domain.place.repository.PlaceRepository;
+import com.wholeseeds.mindle.domain.place.repository.PlaceTypeRepository;
+import com.wholeseeds.mindle.domain.region.entity.Subdistrict;
+import com.wholeseeds.mindle.domain.region.service.RegionService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +27,8 @@ import lombok.extern.slf4j.Slf4j;
 public class PlaceService {
 
 	private final PlaceRepository placeRepository;
+	private final PlaceTypeRepository placeTypeRepository;
+	private final RegionService regionService;
 
 	/**
 	 * 장소 조회
@@ -30,5 +43,198 @@ public class PlaceService {
 		}
 		return placeRepository.findByPlaceId(placeId)
 			.orElseThrow(PlaceNotFoundException::new);
+	}
+
+	/**
+	 * placeId(외부 키)로 Place를 조회하고, 없으면 생성한다. soft-delete면 복구한다.
+	 *
+	 * @param cmd 업서트 입력(외부 placeId 필수, 신규 생성 시 type/name 필요)
+	 * @return 조회/복구/신규 Place (placeId 공백이면 {@code null})
+	 * @throws PlaceTypeRequiredException 신규 생성 요건(placeTypeName) 미충족 시
+	 * @throws PlaceNameRequiredException 신규 생성 요건(placeName) 미충족 시
+	 */
+	@Transactional
+	public Place findOrCreatePlace(PlaceUpsertCmd cmd) {
+		if (!StringUtils.hasText(cmd.getPlaceId())) {
+			return null;
+		}
+
+		// 1) 살아있는 기존 Place
+		Optional<Place> alive = resolveExistingPlace(cmd.getPlaceId());
+		if (alive.isPresent()) {
+			return alive.get();
+		}
+
+		// 2) soft-deleted 복구
+		Optional<Place> softDeleted = placeRepository.findByPlaceId(cmd.getPlaceId());
+		if (softDeleted.isPresent()) {
+			return restoreAndUpdate(softDeleted.get(), cmd);
+		}
+
+		// 3) 신규 생성
+		validateNewPlaceInputs(cmd);
+		PlaceType type = findOrCreatePlaceType(cmd.getPlaceTypeName());
+		Subdistrict sub = resolveSubdistrict(cmd.getSubdistrictCode());
+
+		try {
+			Place created = buildNewPlace(cmd, type, sub);
+			return placeRepository.save(created);
+		} catch (DataIntegrityViolationException e) {
+			return resolveAfterUniqueViolation(cmd.getPlaceId());
+		}
+	}
+
+	/**
+	 * 이름으로 PlaceType을 조회/복구/생성한다. 동시성 충돌 시 재조회로 멱등 보장.
+	 *
+	 * @param typeName PlaceType 이름
+	 * @return 조회/복구/신규 PlaceType
+	 * @throws PlaceNameRequiredException typeName 미지정 시
+	 */
+	public PlaceType findOrCreatePlaceType(String typeName) {
+		if (!StringUtils.hasText(typeName)) {
+			throw new PlaceNameRequiredException();
+		}
+
+		return placeTypeRepository.findByNameAndDeletedAtIsNull(typeName)
+			.or(() -> placeTypeRepository.findByName(typeName)
+				.map(this::restorePlaceType))
+			.orElseGet(() -> createPlaceTypeSafely(typeName));
+	}
+
+	/**
+	 * 살아있는 Place를 placeId로 조회한다.
+	 *
+	 * @param placeId 외부 placeId
+	 * @return 존재하면 Optional(Place), 없으면 Optional.empty()
+	 */
+	private Optional<Place> resolveExistingPlace(String placeId) {
+		return placeRepository.findByPlaceIdAndDeletedAtIsNull(placeId);
+	}
+
+	/**
+	 * soft-deleted Place를 복구하고 옵션 필드를 반영해 저장한다.
+	 *
+	 * @param deleted soft-deleted Place
+	 * @param cmd     옵션 필드가 담긴 커맨드
+	 * @return 저장된 Place
+	 */
+	private Place restoreAndUpdate(Place deleted, PlaceUpsertCmd cmd) {
+		deleted.restore();
+		applyOptionalFields(deleted, cmd);
+		return placeRepository.save(deleted);
+	}
+
+	/**
+	 * 신규 Place를 조립한다.
+	 *
+	 * @param cmd  업서트 입력
+	 * @param type PlaceType (존재/신규)
+	 * @param sub  Subdistrict(선택)
+	 * @return 미저장 Place 인스턴스
+	 */
+	private Place buildNewPlace(PlaceUpsertCmd cmd, PlaceType type, Subdistrict sub) {
+		return Place.builder()
+			.type(type)
+			.subdistrict(sub)
+			.placeId(cmd.getPlaceId())
+			.name(cmd.getPlaceName())
+			.description(cmd.getDescription())
+			.latitude(cmd.getLatitude())
+			.longitude(cmd.getLongitude())
+			.build();
+	}
+
+	/**
+	 * 유니크 제약 위반 발생 시 재조회하여 멱등하게 Place를 반환한다.
+	 *
+	 * @param placeId 외부 placeId
+	 * @return 재조회된 Place(있으면), 없으면 soft-deleted 포함 재조회 결과 또는 null
+	 */
+	private Place resolveAfterUniqueViolation(String placeId) {
+		return placeRepository.findByPlaceIdAndDeletedAtIsNull(placeId)
+			.orElseGet(() -> placeRepository.findByPlaceId(placeId).orElse(null));
+	}
+
+	/**
+	 * Subdistrict 코드를 행정동 엔티티로 해석한다. 공백/미지정이면 null.
+	 *
+	 * @param subdistrictCode 행정동 코드
+	 * @return Subdistrict 또는 null
+	 */
+	private Subdistrict resolveSubdistrict(String subdistrictCode) {
+		if (!StringUtils.hasText(subdistrictCode)) {
+			return null;
+		}
+		return regionService.findSubdistrict(subdistrictCode);
+	}
+
+	/**
+	 * PlaceType을 안전하게 생성한다. 동시성 충돌 시 재조회로 멱등 보장.
+	 *
+	 * @param typeName PlaceType 이름
+	 * @return 생성(또는 경쟁 후 재조회한) PlaceType
+	 */
+	private PlaceType createPlaceTypeSafely(String typeName) {
+		try {
+			return placeTypeRepository.save(PlaceType.builder().name(typeName).build());
+		} catch (DataIntegrityViolationException e) {
+			return placeTypeRepository.findByNameAndDeletedAtIsNull(typeName)
+				.orElseGet(() -> placeTypeRepository.findByName(typeName).orElseThrow());
+		}
+	}
+
+	/**
+	 * soft-deleted PlaceType을 복구해 저장한다.
+	 *
+	 * @param deleted soft-deleted PlaceType
+	 * @return 저장된 PlaceType
+	 */
+	private PlaceType restorePlaceType(PlaceType deleted) {
+		deleted.restore();
+		return placeTypeRepository.save(deleted);
+	}
+
+	/**
+	 * 신규 Place 생성 요건을 검증한다.
+	 *
+	 * @param cmd upsert 입력
+	 * @throws PlaceTypeRequiredException type 미지정 시
+	 * @throws PlaceNameRequiredException name 미지정 시
+	 */
+	private void validateNewPlaceInputs(PlaceUpsertCmd cmd) {
+		if (!StringUtils.hasText(cmd.getPlaceTypeName())) {
+			throw new PlaceTypeRequiredException();
+		}
+		if (!StringUtils.hasText(cmd.getPlaceName())) {
+			throw new PlaceNameRequiredException();
+		}
+	}
+
+	/**
+	 * 기존 Place에 옵션 필드를 반영한다(name/description/lat,lng/subdistrict).
+	 *
+	 * @param target 갱신 대상 Place
+	 * @param cmd    입력(옵션 필드 포함)
+	 */
+	private void applyOptionalFields(Place target, PlaceUpsertCmd cmd) {
+		if (StringUtils.hasText(cmd.getPlaceName())) {
+			target.changeName(cmd.getPlaceName());
+		}
+		if (cmd.getDescription() != null) {
+			target.changeDescription(cmd.getDescription());
+		}
+
+		boolean hasLat = cmd.getLatitude() != null;
+		boolean hasLng = cmd.getLongitude() != null;
+		if (hasLat || hasLng) {
+			Double lat = hasLat ? cmd.getLatitude() : target.getLatitude();
+			Double lng = hasLng ? cmd.getLongitude() : target.getLongitude();
+			target.changeLatLng(lat, lng);
+		}
+
+		if (StringUtils.hasText(cmd.getSubdistrictCode())) {
+			target.changeSubdistrict(regionService.findSubdistrict(cmd.getSubdistrictCode()));
+		}
 	}
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

* [x] #32 

## 📝 작업 내용

* [x] ⭐️ **민원 수정 API** (`PATCH /api/complaint/{complaintId}`) 구현

  * MapStruct 기반 스칼라 필드 patch 적용 (`applyScalarPatch`)
  * 카테고리/행정동/장소는 별도 로직으로 업데이트 처리
  * 이미지 교체(`replaceImages`) 및 추가(`appendImages`) 지원
* [x] ⭐️ **민원 삭제 API** (`DELETE /api/complaint/{complaintId}`) 구현

  * 작성자 본인만 soft delete 가능
  * 연관 이미지도 soft delete 처리
* [x] ⭐️ **Place 업서트 로직 추가**

  * `PlaceService.findOrCreatePlace` 구현 → 존재하지 않으면 신규 생성/soft delete 복구
  * `PlaceType`도 동시성-safe 생성 및 복구 지원
  * 신규 예외(`PlaceTypeRequiredException`, `PlaceNameRequiredException`) 추가
* [x] 민원 응답 DTO 개선

  * `SaveComplaintResponseDto`에 `placeDto` 전체 반환 (기존 placeId 단일 필드 제거)
* [x] Complaint 엔티티에 변경 메서드(`changeCategory`, `changePlace`, `changeLatLng` 등) 추가
* [x] ComplaintImageService 개선

  * 이미지 soft delete / 교체 / 추가 처리 로직 분리
  * 업로드 개수 제한(3장) 검증 강화
* [x] 기타

  * `ErrorCode`에 place 관련 에러코드 및 NOT\_COMPLAINT\_OWNER 추가
  * `UpdateComplaintRequestDto` 신규 추가 (수정 API 전용 DTO)
  * `ObjectUtils.hasText` 추가

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

## 🔮 향후 개발 시 유의점

* Complaint 삭제 시 댓글/공감 등 다른 연관 리소스는 아직 soft delete 처리하지 않았습니다. 향후 필요 시 확장해야 합니다.
* Place 업서트는 placeId(구글 지도 API에서 제공되는 값)를 기준으로 처리합니다.
