### PR TITLE
[Feat] #55 Region 이름 기반 조회 API 추가 & 응답 조립 리팩토링(MapStruct)

### DIFF
--- a/src/main/java/com/wholeseeds/mindle/common/response/ErrorCode.java
+++ b/src/main/java/com/wholeseeds/mindle/common/response/ErrorCode.java
@@ -40,6 +40,7 @@ public enum ErrorCode {
 	SUBDISTRICT_NOT_FOUND(404, "해당 (읍/면/동)를 찾을 수 없습니다"),
 	INVALID_SUBDISTRICT_REFERENCE(400, "Subdistrict는 하나의 City 또는 District만 참조해야 합니다."),
 	INVALID_REGION_TYPE(400, "올바르지 않은 regionType 값입니다. (city, district, subdistrict 중 하나여야 합니다)"),
+	INVALID_REGION_NAME_COMBINATION(400, "입력받은 city, district, subdistrict 이름 조합이 유효하지 않습니다."),
 
 	// NCP
 	NCP_FILE_UPLOAD_FAILED(500, "NCP 에 파일 저장 중 오류가 발생했습니다"),

--- a/src/main/java/com/wholeseeds/mindle/common/util/ObjectUtils.java
+++ b/src/main/java/com/wholeseeds/mindle/common/util/ObjectUtils.java
@@ -34,4 +34,14 @@ public class ObjectUtils {
 		}
 		return LocalDateTime.parse(dateTimeString);
 	}
+
+	/**
+	 * 입력 문자열을 trim 하여 정규화한다. null 입력은 null을 유지.
+	 */
+	public String normalize(String s) {
+		if (s == null) {
+			return null;
+		}
+		return s.trim();
+	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/region/controller/RegionController.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/region/controller/RegionController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.wholeseeds.mindle.common.util.ResponseTemplate;
 import com.wholeseeds.mindle.domain.region.dto.request.RegionDetailRequestDto;
+import com.wholeseeds.mindle.domain.region.dto.request.RegionNameRequestDto;
 import com.wholeseeds.mindle.domain.region.dto.response.RegionDetailResponseDto;
 import com.wholeseeds.mindle.domain.region.enums.RegionType;
 import com.wholeseeds.mindle.domain.region.service.RegionService;
@@ -64,6 +65,36 @@ public class RegionController {
 	) {
 		RegionType type = RegionType.from(request.getRegionType());
 		RegionDetailResponseDto<?> response = regionService.getRegionDetail(type, request.getCode());
+		return responseTemplate.success(response, HttpStatus.OK);
+	}
+
+	@Operation(
+		summary = "행정구역 이름으로 상세 조회",
+		description = """
+		cityName(필수), districtName(선택), subdistrictName(선택)을 조합하여 상세 정보를 반환합니다.
+		허용되는 조합:
+		1) cityName
+		2) cityName + districtName
+		3) cityName + districtName + subdistrictName
+		그 외 조합은 400 에러로 처리됩니다.
+		응답은 RegionDetailResponseDto 형태로, 하위 목록이 포함될 수 있습니다.
+		""",
+		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+			required = true,
+			content = @Content(schema = @Schema(implementation = RegionNameRequestDto.class))
+		)
+	)
+	@ApiResponse(
+		responseCode = "200",
+		description = "행정구역 상세 정보 반환",
+		content = @Content(schema = @Schema(implementation = RegionDetailResponseDto.class))
+	)
+	@PostMapping("/by-name")
+	public ResponseEntity<Map<String, Object>> getRegionDetailByNames(
+		@RequestBody @jakarta.validation.Valid RegionNameRequestDto request
+	) {
+		RegionDetailResponseDto<?> response =
+			regionService.getRegionDetailByNames(request);
 		return responseTemplate.success(response, HttpStatus.OK);
 	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/region/controller/RegionController.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/region/controller/RegionController.java
@@ -77,7 +77,6 @@ public class RegionController {
 		2) cityName + districtName
 		3) cityName + districtName + subdistrictName
 		그 외 조합은 400 에러로 처리됩니다.
-		응답은 RegionDetailResponseDto 형태로, 하위 목록이 포함될 수 있습니다.
 		""",
 		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
 			required = true,

--- a/src/main/java/com/wholeseeds/mindle/domain/region/dto/request/RegionNameRequestDto.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/region/dto/request/RegionNameRequestDto.java
@@ -1,0 +1,24 @@
+package com.wholeseeds.mindle.domain.region.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "행정구역 이름 기반 조회 요청 DTO")
+public class RegionNameRequestDto {
+
+	@NotBlank
+	@Schema(description = "시/도 이름 (필수)", example = "수원시")
+	private String cityName;
+
+	@Schema(description = "시/군/구 이름 (선택)", example = "영통구")
+	private String districtName;
+
+	@Schema(description = "읍/면/동 이름 (선택)", example = "망포1동")
+	private String subdistrictName;
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/region/dto/response/RegionDetailResponseDto.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/region/dto/response/RegionDetailResponseDto.java
@@ -2,74 +2,22 @@ package com.wholeseeds.mindle.domain.region.dto.response;
 
 import java.util.List;
 
-import com.wholeseeds.mindle.domain.region.dto.CityDto;
 import com.wholeseeds.mindle.domain.region.dto.DistrictDto;
 import com.wholeseeds.mindle.domain.region.dto.SubdistrictDto;
 import com.wholeseeds.mindle.domain.region.enums.RegionType;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
 public class RegionDetailResponseDto<T> {
+
 	private final RegionType regionType;
 	private final T region;
 	private final List<DistrictDto> districts;
 	private final List<SubdistrictDto> subdistricts;
-
-	// 타입 안정성을 위한 Factory Methods
-	/**
-	 * City(시/군) 응답 생성
-	 * @param city 시/군 정보
-	 * @param districts 하위 구 목록
-	 * @param subdistricts 하위 읍/면/동 목록
-	 * @return City 타입의 RegionDetailResponseDto
-	 */
-	public static RegionDetailResponseDto<CityDto> forCity(
-		CityDto city,
-		List<DistrictDto> districts,
-		List<SubdistrictDto> subdistricts
-	) {
-		return RegionDetailResponseDto.<CityDto>builder()
-			.regionType(RegionType.CITY)
-			.region(city)
-			.districts(districts)
-			.subdistricts(subdistricts)
-			.build();
-	}
-
-	/**
-	 * District(구) 응답 생성
-	 * @param district 구 정보
-	 * @param subdistricts 하위 읍/면/동 목록
-	 * @return District 타입의 RegionDetailResponseDto
-	 */
-	public static RegionDetailResponseDto<DistrictDto> forDistrict(
-		DistrictDto district,
-		List<SubdistrictDto> subdistricts
-	) {
-		return RegionDetailResponseDto.<DistrictDto>builder()
-			.regionType(RegionType.DISTRICT)
-			.region(district)
-			.districts(null)
-			.subdistricts(subdistricts)
-			.build();
-	}
-
-	/**
-	 * Subdistrict(읍/면/동) 응답 생성
-	 * @param subdistrict 읍/면/동 정보
-	 * @return Subdistrict 타입의 RegionDetailResponseDto
-	 */
-	public static RegionDetailResponseDto<SubdistrictDto> forSubdistrict(
-		SubdistrictDto subdistrict
-	) {
-		return RegionDetailResponseDto.<SubdistrictDto>builder()
-			.regionType(RegionType.SUBDISTRICT)
-			.region(subdistrict)
-			.districts(null)
-			.subdistricts(null)
-			.build();
-	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/region/exception/InvalidRegionNameCombinationException.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/region/exception/InvalidRegionNameCombinationException.java
@@ -1,0 +1,10 @@
+package com.wholeseeds.mindle.domain.region.exception;
+
+import com.wholeseeds.mindle.common.exception.BusinessException;
+import com.wholeseeds.mindle.common.response.ErrorCode;
+
+public class InvalidRegionNameCombinationException extends BusinessException {
+	public InvalidRegionNameCombinationException() {
+		super(ErrorCode.INVALID_REGION_NAME_COMBINATION);
+	}
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/region/mapper/RegionDetailMapper.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/region/mapper/RegionDetailMapper.java
@@ -1,0 +1,62 @@
+package com.wholeseeds.mindle.domain.region.mapper;
+
+import java.util.List;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import com.wholeseeds.mindle.domain.region.dto.CityDto;
+import com.wholeseeds.mindle.domain.region.dto.DistrictDto;
+import com.wholeseeds.mindle.domain.region.dto.SubdistrictDto;
+import com.wholeseeds.mindle.domain.region.dto.response.RegionDetailResponseDto;
+import com.wholeseeds.mindle.domain.region.entity.City;
+import com.wholeseeds.mindle.domain.region.entity.District;
+import com.wholeseeds.mindle.domain.region.entity.Subdistrict;
+import com.wholeseeds.mindle.domain.region.enums.RegionType;
+
+@Mapper(
+	componentModel = "spring",
+	uses = { RegionMapper.class },
+	imports = { RegionType.class }
+)
+public interface RegionDetailMapper {
+
+	/**
+	 * City 상세 응답 조립 (하위 District/Subdistrict 목록 포함)
+	 */
+	@Mapping(target = "regionType", expression = "java(RegionType.CITY)")
+	@Mapping(target = "region", expression = "java(regionMapper.toCityDto(city))")
+	@Mapping(target = "districts", expression = "java(regionMapper.toDistrictDtoList(districts))")
+	@Mapping(target = "subdistricts", expression = "java(regionMapper.toSubdistrictDtoList(subdistricts))")
+	RegionDetailResponseDto<CityDto> toCityDetail(
+		City city,
+		List<District> districts,
+		List<Subdistrict> subdistricts,
+		RegionMapper regionMapper
+	);
+
+	/**
+	 * District 상세 응답 조립 (하위 Subdistrict 목록 포함)
+	 */
+	@Mapping(target = "regionType", expression = "java(RegionType.DISTRICT)")
+	@Mapping(target = "region", expression = "java(regionMapper.toDistrictDto(district))")
+	@Mapping(target = "districts", expression = "java(null)")
+	@Mapping(target = "subdistricts", expression = "java(regionMapper.toSubdistrictDtoList(subdistricts))")
+	RegionDetailResponseDto<DistrictDto> toDistrictDetail(
+		District district,
+		List<Subdistrict> subdistricts,
+		RegionMapper regionMapper
+	);
+
+	/**
+	 * Subdistrict 상세 응답 조립
+	 */
+	@Mapping(target = "regionType", expression = "java(RegionType.SUBDISTRICT)")
+	@Mapping(target = "region", expression = "java(regionMapper.toSubdistrictDto(subdistrict))")
+	@Mapping(target = "districts", expression = "java(null)")
+	@Mapping(target = "subdistricts", expression = "java(null)")
+	RegionDetailResponseDto<SubdistrictDto> toSubdistrictDetail(
+		Subdistrict subdistrict,
+		RegionMapper regionMapper
+	);
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/region/repository/DistrictRepository.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/region/repository/DistrictRepository.java
@@ -12,4 +12,6 @@ public interface DistrictRepository extends JpaRepository<District, String> {
 	Optional<District> findByName(String name);
 
 	List<District> findAllByCityCode(String cityCode);
+
+	Optional<District> findByCityCodeAndName(String cityCode, String name);
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/region/repository/SubdistrictRepository.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/region/repository/SubdistrictRepository.java
@@ -15,4 +15,6 @@ public interface SubdistrictRepository extends JpaRepository<Subdistrict, String
 	List<Subdistrict> findAllByDistrictCode(String districtCode);
 
 	List<Subdistrict> findAllByCityCode(String cityCode);
+
+	Optional<Subdistrict> findByDistrictCodeAndName(String districtCode, String name);
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/region/service/RegionService.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/region/service/RegionService.java
@@ -3,6 +3,8 @@ package com.wholeseeds.mindle.domain.region.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.wholeseeds.mindle.common.util.ObjectUtils;
+import com.wholeseeds.mindle.domain.region.dto.request.RegionNameRequestDto;
 import com.wholeseeds.mindle.domain.region.dto.response.RegionDetailResponseDto;
 import com.wholeseeds.mindle.domain.region.entity.City;
 import com.wholeseeds.mindle.domain.region.entity.District;
@@ -10,6 +12,7 @@ import com.wholeseeds.mindle.domain.region.entity.Subdistrict;
 import com.wholeseeds.mindle.domain.region.enums.RegionType;
 import com.wholeseeds.mindle.domain.region.exception.CityNotFoundException;
 import com.wholeseeds.mindle.domain.region.exception.DistrictNotFoundException;
+import com.wholeseeds.mindle.domain.region.exception.InvalidRegionNameCombinationException;
 import com.wholeseeds.mindle.domain.region.exception.SubdistrictNotFoundException;
 import com.wholeseeds.mindle.domain.region.mapper.RegionMapper;
 import com.wholeseeds.mindle.domain.region.repository.CityRepository;
@@ -30,10 +33,11 @@ public class RegionService {
 	private final RegionMapper regionMapper;
 
 	/**
-	 * City(시/도) 조회
+	 * City(시/도) 조회.
 	 *
-	 * @param cityCode 시/도 코드
-	 * @return City 객체
+	 * @param cityCode 시/도 코드 (null 허용)
+	 * @return City 엔티티 또는 null
+	 * @throws CityNotFoundException 코드가 존재하지 않으면 발생
 	 */
 	@Transactional(readOnly = true)
 	public City findCity(String cityCode) {
@@ -45,10 +49,11 @@ public class RegionService {
 	}
 
 	/**
-	 * District(시/군/구) 조회
+	 * District(시/군/구) 조회.
 	 *
-	 * @param districtCode 시/군/구 코드
-	 * @return District 객체
+	 * @param districtCode 시/군/구 코드 (null 허용)
+	 * @return District 엔티티 또는 null
+	 * @throws DistrictNotFoundException 코드가 존재하지 않으면 발생
 	 */
 	@Transactional(readOnly = true)
 	public District findDistrict(String districtCode) {
@@ -60,10 +65,11 @@ public class RegionService {
 	}
 
 	/**
-	 * Subdistrict(읍/면/동) 조회
+	 * Subdistrict(읍/면/동) 조회.
 	 *
-	 * @param subdistrictCode 읍/면/동 코드
-	 * @return Subdistrict 객체
+	 * @param subdistrictCode 읍/면/동 코드 (null 허용)
+	 * @return Subdistrict 엔티티 또는 null
+	 * @throws SubdistrictNotFoundException 코드가 존재하지 않으면 발생
 	 */
 	@Transactional(readOnly = true)
 	public Subdistrict findSubdistrict(String subdistrictCode) {
@@ -75,36 +81,114 @@ public class RegionService {
 	}
 
 	/**
-	 * 통합 행정구역 상세 정보 조회
+	 * 행정구역 코드 기준 상세 조회.
 	 *
-	 * @param regionType 행정구역 타입
-	 * @param code 행정구역 코드
-	 * @return RegionDetailResponseDto - 일관된 구조의 응답 DTO
+	 * @param regionType 조회할 행정구역 타입
+	 * @param code       행정구역 코드
+	 * @return 일관된 스키마의 상세 응답 DTO
 	 */
 	@Transactional(readOnly = true)
 	public RegionDetailResponseDto<?> getRegionDetail(RegionType regionType, String code) {
 		return switch (regionType) {
-			case CITY -> RegionDetailResponseDto.forCity(
-				regionMapper.toCityDto(
-					cityRepository.findById(code)
-						.orElseThrow(CityNotFoundException::new)),
-				regionMapper.toDistrictDtoList(
-					districtRepository.findAllByCityCode(code)),
-				regionMapper.toSubdistrictDtoList(
-					subdistrictRepository.findAllByCityCode(code))
+			case CITY -> buildCityResponse(
+				cityRepository.findById(code).orElseThrow(CityNotFoundException::new)
 			);
-			case DISTRICT -> RegionDetailResponseDto.forDistrict(
-				regionMapper.toDistrictDto(
-					districtRepository.findById(code)
-						.orElseThrow(DistrictNotFoundException::new)),
-				regionMapper.toSubdistrictDtoList(
-					subdistrictRepository.findAllByDistrictCode(code))
+			case DISTRICT -> buildDistrictResponse(
+				districtRepository.findById(code).orElseThrow(DistrictNotFoundException::new)
 			);
-			case SUBDISTRICT -> RegionDetailResponseDto.forSubdistrict(
-				regionMapper.toSubdistrictDto(
-					subdistrictRepository.findById(code)
-						.orElseThrow(SubdistrictNotFoundException::new))
+			case SUBDISTRICT -> buildSubdistrictResponse(
+				subdistrictRepository.findById(code).orElseThrow(SubdistrictNotFoundException::new)
 			);
 		};
+	}
+
+	/**
+	 * 행정구역 이름 조합(cityName[필수], districtName[선택], subdistrictName[선택])으로 상세 조회.
+	 * 허용 조합은 (1) city, (2) city+district, (3) city+district+subdistrict.
+	 *
+	 * @param req 이름 기반 요청 DTO
+	 * @return 일관된 스키마의 상세 응답 DTO
+	 * @throws InvalidRegionNameCombinationException 허용되지 않는 조합일 경우
+	 * @throws CityNotFoundException                 시/도가 없을 경우
+	 * @throws DistrictNotFoundException             구가 없을 경우
+	 * @throws SubdistrictNotFoundException          읍/면/동이 없을 경우
+	 */
+	@Transactional(readOnly = true)
+	public RegionDetailResponseDto<?> getRegionDetailByNames(RegionNameRequestDto req) {
+		final String cityName = ObjectUtils.normalize(req.getCityName());
+		final String districtName = ObjectUtils.normalize(req.getDistrictName());
+		final String subdistrictName = ObjectUtils.normalize(req.getSubdistrictName());
+
+		validateNameCombination(cityName, districtName, subdistrictName);
+
+		final City city = cityRepository.findByName(cityName)
+			.orElseThrow(CityNotFoundException::new);
+
+		final boolean hasDistrict = districtName != null && !districtName.isBlank();
+		final boolean hasSubdistrict = subdistrictName != null && !subdistrictName.isBlank();
+
+		if (!hasDistrict && !hasSubdistrict) {
+			return buildCityResponse(city);
+		}
+
+		final District district = districtRepository
+			.findByCityCodeAndName(city.getCode(), districtName)
+			.orElseThrow(DistrictNotFoundException::new);
+
+		if (!hasSubdistrict) {
+			return buildDistrictResponse(district);
+		}
+
+		final Subdistrict subdistrict = subdistrictRepository
+			.findByDistrictCodeAndName(district.getCode(), subdistrictName)
+			.orElseThrow(SubdistrictNotFoundException::new);
+
+		return buildSubdistrictResponse(subdistrict);
+	}
+
+	/**
+	 * City 응답을 생성한다. 하위 District/ Subdistrict 목록 포함.
+	 */
+	private RegionDetailResponseDto<?> buildCityResponse(City city) {
+		return RegionDetailResponseDto.forCity(
+			regionMapper.toCityDto(city),
+			regionMapper.toDistrictDtoList(districtRepository.findAllByCityCode(city.getCode())),
+			regionMapper.toSubdistrictDtoList(subdistrictRepository.findAllByCityCode(city.getCode()))
+		);
+	}
+
+	/**
+	 * District 응답을 생성한다. 하위 Subdistrict 목록 포함.
+	 */
+	private RegionDetailResponseDto<?> buildDistrictResponse(District district) {
+		return RegionDetailResponseDto.forDistrict(
+			regionMapper.toDistrictDto(district),
+			regionMapper.toSubdistrictDtoList(subdistrictRepository.findAllByDistrictCode(district.getCode()))
+		);
+	}
+
+	/**
+	 * Subdistrict 응답을 생성한다.
+	 */
+	private RegionDetailResponseDto<?> buildSubdistrictResponse(Subdistrict subdistrict) {
+		return RegionDetailResponseDto.forSubdistrict(
+			regionMapper.toSubdistrictDto(subdistrict)
+		);
+	}
+
+	/**
+	 * 이름 조합의 유효성을 검증한다.
+	 * - cityName은 필수
+	 * - subdistrictName이 있으면 districtName도 반드시 있어야 함
+	 */
+	private void validateNameCombination(String cityName, String districtName, String subdistrictName) {
+		if (cityName == null || cityName.isBlank()) {
+			throw new InvalidRegionNameCombinationException();
+		}
+		if (subdistrictName != null && !subdistrictName.isBlank()) {
+			if (districtName == null || districtName.isBlank()) {
+				throw new InvalidRegionNameCombinationException();
+			}
+		}
 	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/region/service/RegionService.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/region/service/RegionService.java
@@ -14,6 +14,7 @@ import com.wholeseeds.mindle.domain.region.exception.CityNotFoundException;
 import com.wholeseeds.mindle.domain.region.exception.DistrictNotFoundException;
 import com.wholeseeds.mindle.domain.region.exception.InvalidRegionNameCombinationException;
 import com.wholeseeds.mindle.domain.region.exception.SubdistrictNotFoundException;
+import com.wholeseeds.mindle.domain.region.mapper.RegionDetailMapper;
 import com.wholeseeds.mindle.domain.region.mapper.RegionMapper;
 import com.wholeseeds.mindle.domain.region.repository.CityRepository;
 import com.wholeseeds.mindle.domain.region.repository.DistrictRepository;
@@ -31,6 +32,7 @@ public class RegionService {
 	private final DistrictRepository districtRepository;
 	private final SubdistrictRepository subdistrictRepository;
 	private final RegionMapper regionMapper;
+	private final RegionDetailMapper regionDetailMapper;
 
 	/**
 	 * City(시/도) 조회.
@@ -84,30 +86,44 @@ public class RegionService {
 	 * 행정구역 코드 기준 상세 조회.
 	 *
 	 * @param regionType 조회할 행정구역 타입
-	 * @param code       행정구역 코드
-	 * @return 일관된 스키마의 상세 응답 DTO
+	 * @param code 행정구역 코드
+	 * @return 상세 응답 DTO
 	 */
 	@Transactional(readOnly = true)
 	public RegionDetailResponseDto<?> getRegionDetail(RegionType regionType, String code) {
 		return switch (regionType) {
-			case CITY -> buildCityResponse(
-				cityRepository.findById(code).orElseThrow(CityNotFoundException::new)
-			);
-			case DISTRICT -> buildDistrictResponse(
-				districtRepository.findById(code).orElseThrow(DistrictNotFoundException::new)
-			);
-			case SUBDISTRICT -> buildSubdistrictResponse(
-				subdistrictRepository.findById(code).orElseThrow(SubdistrictNotFoundException::new)
-			);
+			case CITY -> {
+				City city = cityRepository.findById(code)
+					.orElseThrow(CityNotFoundException::new);
+				yield regionDetailMapper.toCityDetail(
+					city,
+					districtRepository.findAllByCityCode(city.getCode()),
+					subdistrictRepository.findAllByCityCode(city.getCode()),
+					regionMapper
+				);
+			}
+			case DISTRICT -> {
+				District district = districtRepository.findById(code)
+					.orElseThrow(DistrictNotFoundException::new);
+				yield regionDetailMapper.toDistrictDetail(
+					district,
+					subdistrictRepository.findAllByDistrictCode(district.getCode()),
+					regionMapper
+				);
+			}
+			case SUBDISTRICT -> {
+				Subdistrict subdistrict = subdistrictRepository.findById(code)
+					.orElseThrow(SubdistrictNotFoundException::new);
+				yield regionDetailMapper.toSubdistrictDetail(subdistrict, regionMapper);
+			}
 		};
 	}
 
 	/**
-	 * 행정구역 이름 조합(cityName[필수], districtName[선택], subdistrictName[선택])으로 상세 조회.
-	 * 허용 조합은 (1) city, (2) city+district, (3) city+district+subdistrict.
+	 * 행정구역 이름 조합으로 상세 조회.
 	 *
 	 * @param req 이름 기반 요청 DTO
-	 * @return 일관된 스키마의 상세 응답 DTO
+	 * @return 상세 응답 DTO
 	 * @throws InvalidRegionNameCombinationException 허용되지 않는 조합일 경우
 	 * @throws CityNotFoundException                 시/도가 없을 경우
 	 * @throws DistrictNotFoundException             구가 없을 경우
@@ -121,74 +137,53 @@ public class RegionService {
 
 		validateNameCombination(cityName, districtName, subdistrictName);
 
-		final City city = cityRepository.findByName(cityName)
+		City city = cityRepository.findByName(cityName)
 			.orElseThrow(CityNotFoundException::new);
 
-		final boolean hasDistrict = districtName != null && !districtName.isBlank();
-		final boolean hasSubdistrict = subdistrictName != null && !subdistrictName.isBlank();
+		boolean hasDistrict = districtName != null && !districtName.isBlank();
+		boolean hasSubdistrict = subdistrictName != null && !subdistrictName.isBlank();
 
 		if (!hasDistrict && !hasSubdistrict) {
-			return buildCityResponse(city);
+			return regionDetailMapper.toCityDetail(
+				city,
+				districtRepository.findAllByCityCode(city.getCode()),
+				subdistrictRepository.findAllByCityCode(city.getCode()),
+				regionMapper
+			);
 		}
 
-		final District district = districtRepository
+		District district = districtRepository
 			.findByCityCodeAndName(city.getCode(), districtName)
 			.orElseThrow(DistrictNotFoundException::new);
 
 		if (!hasSubdistrict) {
-			return buildDistrictResponse(district);
+			return regionDetailMapper.toDistrictDetail(
+				district,
+				subdistrictRepository.findAllByDistrictCode(district.getCode()),
+				regionMapper
+			);
 		}
 
-		final Subdistrict subdistrict = subdistrictRepository
+		Subdistrict subdistrict = subdistrictRepository
 			.findByDistrictCodeAndName(district.getCode(), subdistrictName)
 			.orElseThrow(SubdistrictNotFoundException::new);
 
-		return buildSubdistrictResponse(subdistrict);
+		return regionDetailMapper.toSubdistrictDetail(subdistrict, regionMapper);
 	}
 
 	/**
-	 * City 응답을 생성한다. 하위 District/ Subdistrict 목록 포함.
-	 */
-	private RegionDetailResponseDto<?> buildCityResponse(City city) {
-		return RegionDetailResponseDto.forCity(
-			regionMapper.toCityDto(city),
-			regionMapper.toDistrictDtoList(districtRepository.findAllByCityCode(city.getCode())),
-			regionMapper.toSubdistrictDtoList(subdistrictRepository.findAllByCityCode(city.getCode()))
-		);
-	}
-
-	/**
-	 * District 응답을 생성한다. 하위 Subdistrict 목록 포함.
-	 */
-	private RegionDetailResponseDto<?> buildDistrictResponse(District district) {
-		return RegionDetailResponseDto.forDistrict(
-			regionMapper.toDistrictDto(district),
-			regionMapper.toSubdistrictDtoList(subdistrictRepository.findAllByDistrictCode(district.getCode()))
-		);
-	}
-
-	/**
-	 * Subdistrict 응답을 생성한다.
-	 */
-	private RegionDetailResponseDto<?> buildSubdistrictResponse(Subdistrict subdistrict) {
-		return RegionDetailResponseDto.forSubdistrict(
-			regionMapper.toSubdistrictDto(subdistrict)
-		);
-	}
-
-	/**
-	 * 이름 조합의 유효성을 검증한다.
-	 * - cityName은 필수
-	 * - subdistrictName이 있으면 districtName도 반드시 있어야 함
+	 * 이름 조합 유효성 검증
 	 */
 	private void validateNameCombination(String cityName, String districtName, String subdistrictName) {
 		if (cityName == null || cityName.isBlank()) {
 			throw new InvalidRegionNameCombinationException();
 		}
-		if (subdistrictName != null && !subdistrictName.isBlank()) {
-			if (districtName == null || districtName.isBlank()) {
-				throw new InvalidRegionNameCombinationException();
-			}
+
+		final boolean hasSubdistrict = subdistrictName != null && !subdistrictName.isBlank();
+		final boolean missingDistrict = districtName == null || districtName.isBlank();
+
+		if (hasSubdistrict && missingDistrict) {
+			throw new InvalidRegionNameCombinationException();
 		}
 	}
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

* [x] #55 

## 📝 작업 내용

이번 PR에서 작업한 내용을 간략히 설명해주세요

* [x] ⭐️ **이름 기반 조회 API 추가**: `POST /api/region/by-name` (`@RequestBody RegionNameRequestDto`)

  * 허용 조합: `cityName` / `cityName + districtName` / `cityName + districtName + subdistrictName`
  * 응답은 기존 스키마 그대로 `RegionDetailResponseDto<T>` 사용(자식 목록 포함)
* [x] ⭐️ **응답 조립 로직 분리(RegionDetailMapper)**: MapStruct로 `City/District/Subdistrict`별 응답 조립 전담

  * 서비스는 조회/분기에만 집중, 매퍼가 빌더 기반으로 DTO 생성
* [x] **DTO 단순화**: `RegionDetailResponseDto`의 정적 팩토리 메서드 제거 → `@Builder` + `@AllArgsConstructor`만 유지
* [x] **검증/에러 코드 추가**: 잘못된 이름 조합 시 `InvalidRegionNameCombinationException` + `ErrorCode.INVALID_REGION_NAME_COMBINATION`
* [x] **레포지토리 확장**:

  * `DistrictRepository#findByCityCodeAndName`
  * `SubdistrictRepository#findByDistrictCodeAndName`
* [x] **공통 유틸 추가**: `ObjectUtils.normalize(String)`로 입력값 trim 정규화

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


**재사용 코드 예시**

```java
// 이름 정규화 공통 사용
final String city = ObjectUtils.normalize(req.getCityName());

```

## 🔮 향후 개발 시 유의점

