### PR TITLE
[Feat] #57 민원 ‘해결됨’ 투표 API 구현

### DIFF
--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/controller/ComplaintController.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/controller/ComplaintController.java
@@ -29,6 +29,7 @@ import com.wholeseeds.mindle.domain.complaint.dto.request.UpdateComplaintRequest
 import com.wholeseeds.mindle.domain.complaint.dto.response.ComplaintDetailResponseDto;
 import com.wholeseeds.mindle.domain.complaint.dto.response.ComplaintListResponseDto;
 import com.wholeseeds.mindle.domain.complaint.dto.response.SaveComplaintResponseDto;
+import com.wholeseeds.mindle.domain.complaint.dto.response.VoteResolvedResponseDto;
 import com.wholeseeds.mindle.domain.complaint.service.ComplaintService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -196,7 +197,7 @@ public class ComplaintController {
 	@ApiResponse(
 		responseCode = "200",
 		description = "투표 반영 성공",
-		content = @Content(schema = @Schema(implementation = SaveComplaintResponseDto.class))
+		content = @Content(schema = @Schema(implementation = VoteResolvedResponseDto.class))
 	)
 	@PatchMapping("/{complaintId}/resolved-vote")
 	@RequireAuth
@@ -204,7 +205,7 @@ public class ComplaintController {
 		@PathVariable Long complaintId,
 		@Parameter(hidden = true) @CurrentMemberId Long memberId
 	) {
-		SaveComplaintResponseDto responseDto = complaintService.handleResolvedVote(memberId, complaintId);
+		VoteResolvedResponseDto responseDto = complaintService.handleResolvedVote(memberId, complaintId);
 		return responseTemplate.success(responseDto, HttpStatus.OK);
 	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/controller/ComplaintController.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/controller/ComplaintController.java
@@ -185,4 +185,26 @@ public class ComplaintController {
 		complaintService.handleDeleteComplaint(memberId, complaintId);
 		return responseTemplate.success(null, HttpStatus.OK);
 	}
+
+	/**
+	 * “해결됨” 투표 API
+	 */
+	@Operation(
+		summary = "민원 해결됨 투표",
+		description = "특정 민원에 대해 '해결됨' 투표를 1만큼 추가합니다. 누적 5표 시 자동 RESOLVED로 전환합니다."
+	)
+	@ApiResponse(
+		responseCode = "200",
+		description = "투표 반영 성공",
+		content = @Content(schema = @Schema(implementation = SaveComplaintResponseDto.class))
+	)
+	@PatchMapping("/{complaintId}/resolved-vote")
+	@RequireAuth
+	public ResponseEntity<Map<String, Object>> voteResolved(
+		@PathVariable Long complaintId,
+		@Parameter(hidden = true) @CurrentMemberId Long memberId
+	) {
+		SaveComplaintResponseDto responseDto = complaintService.handleResolvedVote(memberId, complaintId);
+		return responseTemplate.success(responseDto, HttpStatus.OK);
+	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/response/SaveComplaintResponseDto.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/response/SaveComplaintResponseDto.java
@@ -24,4 +24,5 @@ public class SaveComplaintResponseDto {
 	private Double longitude;
 	private Complaint.Status status;
 	private Boolean isResolved;
+	private Integer resolvedVoteCount;
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/response/VoteResolvedResponseDto.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/response/VoteResolvedResponseDto.java
@@ -1,0 +1,15 @@
+package com.wholeseeds.mindle.domain.complaint.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class VoteResolvedResponseDto {
+
+	private boolean incremented;
+	private boolean transitionedToResolved;
+	private SaveComplaintResponseDto complaint;
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/Complaint.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/Complaint.java
@@ -63,20 +63,25 @@ public class Complaint extends BaseEntity {
 	@Column(name = "is_resolved")
 	private Boolean isResolved;
 
+	@Builder.Default
+	@Column(name = "resolved_vote_count", nullable = false)
+	private Integer resolvedVoteCount = 0;
+
 	public enum Status {
-		REPORTED,
 		IN_PROGRESS,
 		RESOLVED
 	}
 
-	// 초기값
 	@Override
 	protected void onPrePersist() {
 		if (status == null) {
-			status = Status.REPORTED;
+			status = Status.IN_PROGRESS;
 		}
 		if (isResolved == null) {
 			isResolved = false;
+		}
+		if (resolvedVoteCount == null) {
+			resolvedVoteCount = 0;
 		}
 	}
 
@@ -103,5 +108,18 @@ public class Complaint extends BaseEntity {
 	public void changeLatLng(Double lat, Double lng) {
 		this.latitude = lat;
 		this.longitude = lng;
+	}
+
+	/** 투표 카운트 +1 (호출 시점은 서비스에서 중복 투표 검증 후) */
+	public void incrementResolvedVoteCount() {
+		this.resolvedVoteCount = this.resolvedVoteCount + 1;
+	}
+
+	/** threshold 도달 시 상태를 RESOLVED로, isResolved=true */
+	public void markResolvedIfThresholdReached(int threshold) {
+		if (this.resolvedVoteCount != null && this.resolvedVoteCount >= threshold) {
+			this.status = Status.RESOLVED;
+			this.isResolved = true;
+		}
 	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/ComplaintResolvedVote.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/ComplaintResolvedVote.java
@@ -1,0 +1,46 @@
+package com.wholeseeds.mindle.domain.complaint.entity;
+
+import com.wholeseeds.mindle.common.entity.BaseEntity;
+import com.wholeseeds.mindle.domain.member.entity.Member;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+	name = "complaint_resolved_vote",
+	uniqueConstraints = @UniqueConstraint(
+		name = "uk_complaint_resolved_vote_complaint_member",
+		columnNames = {"complaint_id", "member_id"}
+	)
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ComplaintResolvedVote extends BaseEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "complaint_id", nullable = false)
+	private Complaint complaint;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+
+	public static ComplaintResolvedVote of(Complaint complaint, Member member) {
+		return ComplaintResolvedVote.builder()
+			.complaint(complaint)
+			.member(member)
+			.build();
+	}
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/mapper/ComplaintMapper.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/mapper/ComplaintMapper.java
@@ -18,6 +18,7 @@ public interface ComplaintMapper {
 	@Mapping(target = "memberId", source = "member.id")
 	@Mapping(target = "subdistrictDto", source = "subdistrict")
 	@Mapping(target = "placeDto", source = "place")
+	@Mapping(target = "resolvedVoteCount", source = "resolvedVoteCount")
 	SaveComplaintResponseDto toSaveComplaintResponseDto(Complaint complaint);
 
 	@BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/repository/ComplaintResolvedVoteRepository.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/repository/ComplaintResolvedVoteRepository.java
@@ -1,0 +1,8 @@
+package com.wholeseeds.mindle.domain.complaint.repository;
+
+import com.wholeseeds.mindle.common.repository.JpaBaseRepository;
+import com.wholeseeds.mindle.domain.complaint.entity.ComplaintResolvedVote;
+
+public interface ComplaintResolvedVoteRepository extends JpaBaseRepository<ComplaintResolvedVote, Long> {
+	boolean existsByComplaintIdAndMemberId(Long complaintId, Long memberId);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true # sql 로그 출력
     properties:
       hibernate:


### PR DESCRIPTION
## #️⃣ 연관된 이슈

* [x] #57 

## 📝 작업 내용

이번 PR에서 작업한 내용을 간략히 설명해주세요

* [x] ⭐️ `PATCH /{complaintId}/resolved-vote` API 추가 및 Swagger 문서화 (멤버 인증 필요)
* [x] ⭐️ 서비스 로직: 동일 회원 중복 투표 방지, 이미 RESOLVED인 경우 멱등 처리, 누적 5표 시 자동 `RESOLVED` 전환
* [x] 엔티티 변경: `Complaint`에 `resolvedVoteCount`(기본 0) 추가, 초기 상태 기본값을 `IN_PROGRESS`로 변경, `REPORTED` 제거
* [x] 신규 엔티티: `ComplaintResolvedVote` 추가 및 `(complaint_id, member_id)` 유니크 제약으로 중복 투표 차단
* [x] DTO/매퍼: `SaveComplaintResponseDto.resolvedVoteCount` 필드 추가, 응답용 `VoteResolvedResponseDto`(incremented, transitionedToResolved, complaint) 신설, `ComplaintMapper` 매핑 보강
* [x] 리포지토리: `ComplaintResolvedVoteRepository.existsByComplaintIdAndMemberId` 추가
* [x] 설정: `spring.jpa.hibernate.ddl-auto`를 `update`로 변경 (개발/테스트 환경에서 스키마 반영 목적)

### 스크린샷 (선택)

<img width="990" height="745" alt="image" src="https://github.com/user-attachments/assets/fab0ef44-88d0-401c-bc3a-00941d27984b" />
