### PR TITLE
[Refactor] #61 Complaint 생성/수정 로직 MapStruct로 위임, RelationResolver 도입

### DIFF
--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/mapper/ComplaintMapper.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/mapper/ComplaintMapper.java
@@ -1,19 +1,25 @@
 package com.wholeseeds.mindle.domain.complaint.mapper;
 
 import org.mapstruct.BeanMapping;
+import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.NullValuePropertyMappingStrategy;
 
+import com.wholeseeds.mindle.domain.complaint.dto.request.SaveComplaintRequestDto;
 import com.wholeseeds.mindle.domain.complaint.dto.request.UpdateComplaintRequestDto;
 import com.wholeseeds.mindle.domain.complaint.dto.response.SaveComplaintResponseDto;
 import com.wholeseeds.mindle.domain.complaint.entity.Complaint;
 import com.wholeseeds.mindle.domain.place.mapper.PlaceMapper;
 import com.wholeseeds.mindle.domain.region.mapper.RegionMapper;
 
-@Mapper(componentModel = "spring", uses = {RegionMapper.class, PlaceMapper.class})
+@Mapper(
+	componentModel = "spring",
+	uses = {RegionMapper.class, PlaceMapper.class, ComplaintRelationMapper.class}
+)
 public interface ComplaintMapper {
+
 	@Mapping(target = "categoryId", source = "category.id")
 	@Mapping(target = "memberId", source = "member.id")
 	@Mapping(target = "subdistrictDto", source = "subdistrict")
@@ -23,4 +29,39 @@ public interface ComplaintMapper {
 
 	@BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
 	void applyScalarPatch(UpdateComplaintRequestDto dto, @MappingTarget Complaint target);
+
+	@Mapping(target = "category", source = "dto.categoryId")
+	@Mapping(target = "member", source = "memberId")
+	@Mapping(target = "subdistrict", source = "dto", qualifiedByName = "toSubdistrictFromSave")
+	@Mapping(target = "place", source = "dto", qualifiedByName = "toPlaceFromSave")
+	@Mapping(target = "title", source = "dto.title")
+	@Mapping(target = "content", source = "dto.content")
+	@Mapping(target = "latitude", source = "dto.latitude")
+	@Mapping(target = "longitude", source = "dto.longitude")
+	@Mapping(target = "status", ignore = true)
+	@Mapping(target = "isResolved", ignore = true)
+	@Mapping(target = "resolvedVoteCount", ignore = true)
+	Complaint toNewComplaint(
+		Long memberId,
+		SaveComplaintRequestDto dto,
+		@Context ComplaintRelationMapper resolver
+	);
+
+	default void applyRelationsPatch(
+		UpdateComplaintRequestDto dto,
+		@MappingTarget Complaint target,
+		@Context ComplaintRelationMapper resolver
+	) {
+		if (dto.getCategoryId() != null) {
+			target.changeCategory(resolver.toCategory(dto.getCategoryId()));
+		}
+		if (dto.getSubdistrictCode() != null) {
+			target.changeSubdistrict(resolver.toSubdistrict(dto.getSubdistrictCode()));
+		}
+		if (Boolean.TRUE.equals(dto.getClearPlace())) {
+			target.changePlace(null);
+		} else if (dto.getPlaceId() != null) {
+			target.changePlace(resolver.toPlaceFromUpdate(dto));
+		}
+	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/mapper/ComplaintMapper.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/mapper/ComplaintMapper.java
@@ -32,7 +32,7 @@ public interface ComplaintMapper {
 
 	@Mapping(target = "category", source = "dto.categoryId")
 	@Mapping(target = "member", source = "memberId")
-	@Mapping(target = "subdistrict", source = "dto", qualifiedByName = "toSubdistrictFromSave")
+	@Mapping(target = "subdistrict", source = "dto.subdistrictCode") // ★ 여기만 변경
 	@Mapping(target = "place", source = "dto", qualifiedByName = "toPlaceFromSave")
 	@Mapping(target = "title", source = "dto.title")
 	@Mapping(target = "content", source = "dto.content")

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/mapper/ComplaintMapper.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/mapper/ComplaintMapper.java
@@ -32,7 +32,7 @@ public interface ComplaintMapper {
 
 	@Mapping(target = "category", source = "dto.categoryId")
 	@Mapping(target = "member", source = "memberId")
-	@Mapping(target = "subdistrict", source = "dto.subdistrictCode") // ★ 여기만 변경
+	@Mapping(target = "subdistrict", source = "dto.subdistrictCode")
 	@Mapping(target = "place", source = "dto", qualifiedByName = "toPlaceFromSave")
 	@Mapping(target = "title", source = "dto.title")
 	@Mapping(target = "content", source = "dto.content")

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/mapper/ComplaintRelationMapper.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/mapper/ComplaintRelationMapper.java
@@ -26,8 +26,6 @@ public class ComplaintRelationMapper {
 	private final RegionService regionService;
 	private final PlaceService placeService;
 
-	/* --- 단건 ID → 엔티티 해석 --- */
-
 	public Category toCategory(Long id) {
 		return categoryService.findCategory(id);
 	}
@@ -37,11 +35,9 @@ public class ComplaintRelationMapper {
 	}
 
 	public Subdistrict toSubdistrict(String code) {
-		// Save/Update 공통: 유효하지 않으면 서비스에서 예외 발생
 		return regionService.findSubdistrict(code);
 	}
 
-	/* --- Save DTO → Place 해석 (placeId 없으면 null) --- */
 	@Named("toPlaceFromSave")
 	public Place toPlaceFromSave(SaveComplaintRequestDto dto) {
 		if (dto.getPlaceId() == null || dto.getPlaceId().isBlank()) {
@@ -59,8 +55,6 @@ public class ComplaintRelationMapper {
 		return placeService.findOrCreatePlace(cmd);
 	}
 
-	/* --- Update DTO → Place 해석 (placeId 없으면 null) --- */
-
 	@Named("toPlaceFromUpdate")
 	public Place toPlaceFromUpdate(UpdateComplaintRequestDto dto) {
 		if (dto.getPlaceId() == null || dto.getPlaceId().isBlank()) {
@@ -77,10 +71,4 @@ public class ComplaintRelationMapper {
 			.build();
 		return placeService.findOrCreatePlace(cmd);
 	}
-
-	@Named("toSubdistrictFromSave")
-	public Subdistrict toSubdistrictFromSave(SaveComplaintRequestDto dto) {
-		return regionService.findSubdistrict(dto.getSubdistrictCode());
-	}
 }
-

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/mapper/ComplaintRelationMapper.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/mapper/ComplaintRelationMapper.java
@@ -40,34 +40,51 @@ public class ComplaintRelationMapper {
 
 	@Named("toPlaceFromSave")
 	public Place toPlaceFromSave(SaveComplaintRequestDto dto) {
-		if (dto.getPlaceId() == null || dto.getPlaceId().isBlank()) {
-			return null;
-		}
-		PlaceUpsertCmd cmd = PlaceUpsertCmd.builder()
-			.placeId(dto.getPlaceId())
-			.placeTypeName(dto.getPlaceType())
-			.placeName(dto.getPlaceName())
-			.description(dto.getPlaceDescription())
-			.latitude(dto.getLatitude())
-			.longitude(dto.getLongitude())
-			.subdistrictCode(dto.getSubdistrictCode())
-			.build();
-		return placeService.findOrCreatePlace(cmd);
+		return toPlaceCore(
+			dto.getPlaceId(),
+			dto.getPlaceType(),
+			dto.getPlaceName(),
+			dto.getPlaceDescription(),
+			dto.getLatitude(),
+			dto.getLongitude(),
+			dto.getSubdistrictCode()
+		);
 	}
 
 	@Named("toPlaceFromUpdate")
 	public Place toPlaceFromUpdate(UpdateComplaintRequestDto dto) {
-		if (dto.getPlaceId() == null || dto.getPlaceId().isBlank()) {
+		return toPlaceCore(
+			dto.getPlaceId(),
+			dto.getPlaceType(),
+			dto.getPlaceName(),
+			dto.getPlaceDescription(),
+			dto.getLatitude(),
+			dto.getLongitude(),
+			dto.getSubdistrictCode()
+		);
+	}
+
+	/* 공통 Place 생성/업서트 로직 */
+	private Place toPlaceCore(
+		String placeId,
+		String placeType,
+		String placeName,
+		String description,
+		Double latitude,
+		Double longitude,
+		String subdistrictCode
+	) {
+		if (placeId == null || placeId.isBlank()) {
 			return null;
 		}
 		PlaceUpsertCmd cmd = PlaceUpsertCmd.builder()
-			.placeId(dto.getPlaceId())
-			.placeTypeName(dto.getPlaceType())
-			.placeName(dto.getPlaceName())
-			.description(dto.getPlaceDescription())
-			.latitude(dto.getLatitude())
-			.longitude(dto.getLongitude())
-			.subdistrictCode(dto.getSubdistrictCode())
+			.placeId(placeId)
+			.placeTypeName(placeType)
+			.placeName(placeName)
+			.description(description)
+			.latitude(latitude)
+			.longitude(longitude)
+			.subdistrictCode(subdistrictCode)
 			.build();
 		return placeService.findOrCreatePlace(cmd);
 	}

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/mapper/ComplaintRelationMapper.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/mapper/ComplaintRelationMapper.java
@@ -1,0 +1,86 @@
+package com.wholeseeds.mindle.domain.complaint.mapper;
+
+import org.mapstruct.Named;
+import org.springframework.stereotype.Component;
+
+import com.wholeseeds.mindle.domain.category.entity.Category;
+import com.wholeseeds.mindle.domain.category.service.CategoryService;
+import com.wholeseeds.mindle.domain.complaint.dto.request.SaveComplaintRequestDto;
+import com.wholeseeds.mindle.domain.complaint.dto.request.UpdateComplaintRequestDto;
+import com.wholeseeds.mindle.domain.member.entity.Member;
+import com.wholeseeds.mindle.domain.member.service.MemberService;
+import com.wholeseeds.mindle.domain.place.dto.command.PlaceUpsertCmd;
+import com.wholeseeds.mindle.domain.place.entity.Place;
+import com.wholeseeds.mindle.domain.place.service.PlaceService;
+import com.wholeseeds.mindle.domain.region.entity.Subdistrict;
+import com.wholeseeds.mindle.domain.region.service.RegionService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ComplaintRelationMapper {
+
+	private final CategoryService categoryService;
+	private final MemberService memberService;
+	private final RegionService regionService;
+	private final PlaceService placeService;
+
+	/* --- 단건 ID → 엔티티 해석 --- */
+
+	public Category toCategory(Long id) {
+		return categoryService.findCategory(id);
+	}
+
+	public Member toMember(Long id) {
+		return memberService.getMember(id);
+	}
+
+	public Subdistrict toSubdistrict(String code) {
+		// Save/Update 공통: 유효하지 않으면 서비스에서 예외 발생
+		return regionService.findSubdistrict(code);
+	}
+
+	/* --- Save DTO → Place 해석 (placeId 없으면 null) --- */
+	@Named("toPlaceFromSave")
+	public Place toPlaceFromSave(SaveComplaintRequestDto dto) {
+		if (dto.getPlaceId() == null || dto.getPlaceId().isBlank()) {
+			return null;
+		}
+		PlaceUpsertCmd cmd = PlaceUpsertCmd.builder()
+			.placeId(dto.getPlaceId())
+			.placeTypeName(dto.getPlaceType())
+			.placeName(dto.getPlaceName())
+			.description(dto.getPlaceDescription())
+			.latitude(dto.getLatitude())
+			.longitude(dto.getLongitude())
+			.subdistrictCode(dto.getSubdistrictCode())
+			.build();
+		return placeService.findOrCreatePlace(cmd);
+	}
+
+	/* --- Update DTO → Place 해석 (placeId 없으면 null) --- */
+
+	@Named("toPlaceFromUpdate")
+	public Place toPlaceFromUpdate(UpdateComplaintRequestDto dto) {
+		if (dto.getPlaceId() == null || dto.getPlaceId().isBlank()) {
+			return null;
+		}
+		PlaceUpsertCmd cmd = PlaceUpsertCmd.builder()
+			.placeId(dto.getPlaceId())
+			.placeTypeName(dto.getPlaceType())
+			.placeName(dto.getPlaceName())
+			.description(dto.getPlaceDescription())
+			.latitude(dto.getLatitude())
+			.longitude(dto.getLongitude())
+			.subdistrictCode(dto.getSubdistrictCode())
+			.build();
+		return placeService.findOrCreatePlace(cmd);
+	}
+
+	@Named("toSubdistrictFromSave")
+	public Subdistrict toSubdistrictFromSave(SaveComplaintRequestDto dto) {
+		return regionService.findSubdistrict(dto.getSubdistrictCode());
+	}
+}
+


### PR DESCRIPTION
## #️⃣ 연관된 이슈

* [x] #61 

## 📝 작업 내용

이번 PR에서 작업한 내용을 간략히 설명해주세요

* [x] `ComplaintMapper` 확장: `toNewComplaint(Long memberId, SaveComplaintRequestDto dto, @Context ComplaintRelationMapper resolver)` 추가 및 연관 필드 매핑(`category`, `member`, `subdistrict`, `place`)을 Mapper 레벨로 위임. `status/isResolved/resolvedVoteCount`는 `ignore` 처리.
* [x] `applyRelationsPatch`를 Mapper의 `default` 메서드로 이전하여 `clearPlace`/`placeId` 등 연관 변경 로직을 일관되게 처리.
* [x] `ComplaintRelationMapper` 신규 도입(@Component): `Category/Member/Subdistrict/Place` 해석 전담. `@Named` 메서드(`toPlaceFromSave`, `toPlaceFromUpdate`, `toSubdistrictFromSave`)로 MapStruct `qualifiedByName` 매핑 지원.
* [x] `ComplaintService` 정리: 생성/수정 시 엔티티 조립·연관 패치를 Mapper(+Resolver)로 이관. 직접 의존하던 `CategoryService/RegionService/PlaceService` 기반의 조립·헬퍼 메서드(assemble/buildCmd\*/createOrResolvePlaceIfPresent 등) 제거. 중복/장황 주석도 정리.
* [x] “해결됨” 투표 처리 로직은 기능 변경 없이 기존 동작 유지(멱등/임계치 전환 포함).

### 스크린샷 (선택)

