### PR TITLE
[Feat] #63 민원 공감(Reaction) 업데이트 API 구현

### DIFF
--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/controller/ComplaintController.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/controller/ComplaintController.java
@@ -22,6 +22,7 @@ import com.wholeseeds.mindle.common.annotation.CurrentMemberId;
 import com.wholeseeds.mindle.common.annotation.RequireAuth;
 import com.wholeseeds.mindle.common.util.ResponseTemplate;
 import com.wholeseeds.mindle.domain.complaint.dto.CommentDto;
+import com.wholeseeds.mindle.domain.complaint.dto.ReactionDto;
 import com.wholeseeds.mindle.domain.complaint.dto.request.CommentRequestDto;
 import com.wholeseeds.mindle.domain.complaint.dto.request.ComplaintListRequestDto;
 import com.wholeseeds.mindle.domain.complaint.dto.request.SaveComplaintRequestDto;
@@ -206,6 +207,50 @@ public class ComplaintController {
 		@Parameter(hidden = true) @CurrentMemberId Long memberId
 	) {
 		VoteResolvedResponseDto responseDto = complaintService.handleResolvedVote(memberId, complaintId);
+		return responseTemplate.success(responseDto, HttpStatus.OK);
+	}
+
+	/**
+	 * 민원 공감 추가 API
+	 */
+	@Operation(
+		summary = "민원 공감 추가",
+		description = "특정 민원에 공감을 추가합니다. 이미 공감한 상태여도 멱등하게 처리됩니다."
+	)
+	@ApiResponse(
+		responseCode = "200",
+		description = "공감 추가 성공",
+		content = @Content(schema = @Schema(implementation = ReactionDto.class))
+	)
+	@PostMapping("/{complaintId}/reaction")
+	@RequireAuth
+	public ResponseEntity<Map<String, Object>> addReaction(
+		@PathVariable Long complaintId,
+		@Parameter(hidden = true) @CurrentMemberId Long memberId
+	) {
+		ReactionDto responseDto = complaintService.addReaction(memberId, complaintId);
+		return responseTemplate.success(responseDto, HttpStatus.OK);
+	}
+
+	/**
+	 * 민원 공감 취소 API
+	 */
+	@Operation(
+		summary = "민원 공감 취소",
+		description = "특정 민원에 대해 추가된 공감을 취소합니다. 이미 취소된 상태여도 멱등하게 처리됩니다."
+	)
+	@ApiResponse(
+		responseCode = "200",
+		description = "공감 취소 성공",
+		content = @Content(schema = @Schema(implementation = ReactionDto.class))
+	)
+	@DeleteMapping("/{complaintId}/reaction")
+	@RequireAuth
+	public ResponseEntity<Map<String, Object>> cancelReaction(
+		@PathVariable Long complaintId,
+		@Parameter(hidden = true) @CurrentMemberId Long memberId
+	) {
+		ReactionDto responseDto = complaintService.cancelReaction(memberId, complaintId);
 		return responseTemplate.success(responseDto, HttpStatus.OK);
 	}
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/request/ReactionUpdateRequestDto.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/request/ReactionUpdateRequestDto.java
@@ -1,0 +1,14 @@
+package com.wholeseeds.mindle.domain.complaint.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReactionUpdateRequestDto {
+	@NotNull
+	private Boolean reacted;
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/ComplaintReaction.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/entity/ComplaintReaction.java
@@ -8,6 +8,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,7 +16,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "complaint_reaction")
+@Table(
+	name = "complaint_reaction",
+	uniqueConstraints = @UniqueConstraint(
+		name = "uk_complaint_reaction_complaint_member",
+		columnNames = {"complaint_id", "member_id"}
+	)
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -30,3 +37,4 @@ public class ComplaintReaction extends BaseEntity {
 	@JoinColumn(name = "complaint_id", nullable = false)
 	private Complaint complaint;
 }
+

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/repository/ComplaintReactionRepository.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/repository/ComplaintReactionRepository.java
@@ -1,0 +1,15 @@
+package com.wholeseeds.mindle.domain.complaint.repository;
+
+import java.util.Optional;
+
+import com.wholeseeds.mindle.common.repository.JpaBaseRepository;
+import com.wholeseeds.mindle.domain.complaint.entity.ComplaintReaction;
+
+public interface ComplaintReactionRepository extends JpaBaseRepository<ComplaintReaction, Long> {
+
+	Optional<ComplaintReaction> findByComplaintIdAndMemberId(Long complaintId, Long memberId);
+
+	Optional<ComplaintReaction> findByComplaintIdAndMemberIdAndDeletedAtIsNull(Long complaintId, Long memberId);
+
+	boolean existsByComplaintIdAndMemberIdAndDeletedAtIsNull(Long complaintId, Long memberId);
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

* [x] #63 

## 📝 작업 내용

이번 PR에서 작업한 내용을 간략히 설명해주세요

* [x] ⭐️ **API 추가**: `PATCH /{complaintId}/reaction` — `ReactionUpdateRequestDto { reacted: boolean }` 값에 따라 공감 추가/취소를 한 엔드포인트로 처리하도록 구현
* [x] **서비스 로직**: `addReaction(memberId, complaintId)` / `cancelReaction(memberId, complaintId)`

  * 활성 공감 존재 시 **멱등 처리**(변경 없음)
  * 과거 soft delete 이력 존재 시 **restore**
  * 동시성으로 유니크 제약 충돌 발생 시 `DataIntegrityViolationException` 캐치로 **멱등 보장**
* [x] **엔티티/제약**: `ComplaintReaction`에 `(complaint_id, member_id)` 유니크 제약(`uk_complaint_reaction_complaint_member`) 추가
* [x] **리포지토리**: `ComplaintReactionRepository` 신설 및 활성/전체 조회 메서드 추가
  (`findByComplaintIdAndMemberId[AndDeletedAtIsNull]`, `existsBy...AndDeletedAtIsNull`)
* [x] **응답 일원화**: 최신 공감 수 및 내 공감 여부는 `complaintRepository.getReaction(complaintId, memberId)`로 조회하여 반환

### 스크린샷 (선택)

