### PR TITLE
[Feat] #59 내가 작성한/공감한 민원 목록 조회 API 추가 (커서 기반)

### DIFF
--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/controller/ComplaintController.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/controller/ComplaintController.java
@@ -26,6 +26,8 @@ import com.wholeseeds.mindle.domain.complaint.dto.CommentDto;
 import com.wholeseeds.mindle.domain.complaint.dto.ReactionDto;
 import com.wholeseeds.mindle.domain.complaint.dto.request.CommentRequestDto;
 import com.wholeseeds.mindle.domain.complaint.dto.request.ComplaintListRequestDto;
+import com.wholeseeds.mindle.domain.complaint.dto.request.MyComplaintListRequestDto;
+import com.wholeseeds.mindle.domain.complaint.dto.request.MyReactedComplaintListRequestDto;
 import com.wholeseeds.mindle.domain.complaint.dto.request.ReactionUpdateRequestDto;
 import com.wholeseeds.mindle.domain.complaint.dto.request.SaveComplaintRequestDto;
 import com.wholeseeds.mindle.domain.complaint.dto.request.UpdateComplaintRequestDto;
@@ -42,6 +44,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -141,6 +144,58 @@ public class ComplaintController {
 	@RequireAuth
 	public ResponseEntity<Map<String, Object>> getComplaintList(@ModelAttribute ComplaintListRequestDto requestDto) {
 		List<ComplaintListResponseDto> responseDtos = complaintService.getComplaintListResponse(requestDto);
+		return responseTemplate.success(responseDtos, HttpStatus.OK);
+	}
+
+	/**
+	 * 내가 작성한 민원 목록 조회 API
+	 */
+	@Operation(
+		summary = "내가 작성한 민원 목록 조회",
+		description = "로그인 사용자가 작성한 민원 목록을 커서 기반으로 조회합니다."
+	)
+	@ApiResponse(
+		responseCode = "200",
+		description = "민원 목록 반환",
+		content = @Content(
+			mediaType = "application/json",
+			array = @ArraySchema(schema = @Schema(implementation = ComplaintListResponseDto.class))
+		)
+	)
+	@GetMapping("/my/list")
+	@RequireAuth
+	public ResponseEntity<Map<String, Object>> getMyComplaintList(
+		@Parameter(hidden = true) @CurrentMemberId Long memberId,
+		@Valid @ModelAttribute MyComplaintListRequestDto requestDto
+	) {
+		List<ComplaintListResponseDto> responseDtos =
+			complaintService.getMyComplaintList(memberId, requestDto);
+		return responseTemplate.success(responseDtos, HttpStatus.OK);
+	}
+
+	/**
+	 * 내가 공감한 민원 목록 조회 API
+	 */
+	@Operation(
+		summary = "내가 공감한 민원 목록 조회",
+		description = "로그인 사용자가 공감한 민원 목록을 커서 기반으로 조회합니다."
+	)
+	@ApiResponse(
+		responseCode = "200",
+		description = "민원 목록 반환",
+		content = @Content(
+			mediaType = "application/json",
+			array = @ArraySchema(schema = @Schema(implementation = ComplaintListResponseDto.class))
+		)
+	)
+	@GetMapping("/my/reacted")
+	@RequireAuth
+	public ResponseEntity<Map<String, Object>> getMyReactedComplaintList(
+		@Parameter(hidden = true) @CurrentMemberId Long memberId,
+		@Valid @ModelAttribute MyReactedComplaintListRequestDto requestDto
+	) {
+		List<ComplaintListResponseDto> responseDtos =
+			complaintService.getMyReactedComplaintList(memberId, requestDto);
 		return responseTemplate.success(responseDtos, HttpStatus.OK);
 	}
 

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/controller/ComplaintController.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/controller/ComplaintController.java
@@ -142,7 +142,9 @@ public class ComplaintController {
 	)
 	@GetMapping("/list")
 	@RequireAuth
-	public ResponseEntity<Map<String, Object>> getComplaintList(@ModelAttribute ComplaintListRequestDto requestDto) {
+	public ResponseEntity<Map<String, Object>> getComplaintList(
+		@Valid @ModelAttribute ComplaintListRequestDto requestDto
+	) {
 		List<ComplaintListResponseDto> responseDtos = complaintService.getComplaintListResponse(requestDto);
 		return responseTemplate.success(responseDtos, HttpStatus.OK);
 	}

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/request/ComplaintListRequestDto.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/request/ComplaintListRequestDto.java
@@ -1,5 +1,6 @@
 package com.wholeseeds.mindle.domain.complaint.dto.request;
 
+import jakarta.validation.constraints.Min;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,7 +11,8 @@ import lombok.NoArgsConstructor;
 public class ComplaintListRequestDto {
 
 	private Long cursorComplaintId;
-	private int pageSize;
+	@Min(1)
+	private int pageSize = 20;
 	private String cityCode;
 	private String districtCode;
 	private Long categoryId;

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/request/MyComplaintListRequestDto.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/request/MyComplaintListRequestDto.java
@@ -1,0 +1,17 @@
+package com.wholeseeds.mindle.domain.complaint.dto.request;
+
+import jakarta.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MyComplaintListRequestDto {
+
+	private Long cursorComplaintId;
+
+	@Min(1)
+	private int pageSize = 20;
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/request/MyReactedComplaintListRequestDto.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/dto/request/MyReactedComplaintListRequestDto.java
@@ -1,0 +1,17 @@
+package com.wholeseeds.mindle.domain.complaint.dto.request;
+
+import jakarta.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MyReactedComplaintListRequestDto {
+
+	private Long cursorComplaintId;
+
+	@Min(1)
+	private int pageSize = 20; // 기본값
+}

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/repository/custom/ComplaintRepositoryCustom.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/repository/custom/ComplaintRepositoryCustom.java
@@ -23,4 +23,16 @@ public interface ComplaintRepositoryCustom {
 		String districtCode,
 		Long categoryId
 	);
+
+	List<ComplaintListResponseDto> findMyListWithCursor(
+		Long memberId,
+		Long cursorComplaintId,
+		int pageSize
+	);
+
+	List<ComplaintListResponseDto> findReactedListWithCursor(
+		Long memberId,
+		Long cursorComplaintId,
+		int pageSize
+	);
 }

--- a/src/main/java/com/wholeseeds/mindle/domain/complaint/service/ComplaintService.java
+++ b/src/main/java/com/wholeseeds/mindle/domain/complaint/service/ComplaintService.java
@@ -14,6 +14,8 @@ import com.wholeseeds.mindle.domain.complaint.dto.ComplaintDetailWithImagesDto;
 import com.wholeseeds.mindle.domain.complaint.dto.ReactionDto;
 import com.wholeseeds.mindle.domain.complaint.dto.request.CommentRequestDto;
 import com.wholeseeds.mindle.domain.complaint.dto.request.ComplaintListRequestDto;
+import com.wholeseeds.mindle.domain.complaint.dto.request.MyComplaintListRequestDto;
+import com.wholeseeds.mindle.domain.complaint.dto.request.MyReactedComplaintListRequestDto;
 import com.wholeseeds.mindle.domain.complaint.dto.request.SaveComplaintRequestDto;
 import com.wholeseeds.mindle.domain.complaint.dto.request.UpdateComplaintRequestDto;
 import com.wholeseeds.mindle.domain.complaint.dto.response.ComplaintDetailResponseDto;
@@ -126,6 +128,41 @@ public class ComplaintService {
 			dto.getCityCode(),
 			dto.getDistrictCode(),
 			dto.getCategoryId()
+		);
+	}
+
+	/**
+	 * 내가 작성한 민원 목록을 커서 기반으로 조회한다.
+	 *
+	 * @param memberId 조회 회원 ID
+	 * @param dto      목록 조회 요청(커서/사이즈)
+	 * @return 민원 목록 DTO
+	 */
+	@Transactional(readOnly = true)
+	public List<ComplaintListResponseDto> getMyComplaintList(Long memberId, MyComplaintListRequestDto dto) {
+		return complaintRepository.findMyListWithCursor(
+			memberId,
+			dto.getCursorComplaintId(),
+			dto.getPageSize()
+		);
+	}
+
+	/**
+	 * 내가 공감한 민원 목록을 커서 기반으로 조회한다.
+	 *
+	 * @param memberId 조회 회원 ID
+	 * @param dto      목록 조회 요청(커서/사이즈)
+	 * @return 민원 목록 DTO
+	 */
+	@Transactional(readOnly = true)
+	public List<ComplaintListResponseDto> getMyReactedComplaintList(
+		Long memberId,
+		MyReactedComplaintListRequestDto dto
+	) {
+		return complaintRepository.findReactedListWithCursor(
+			memberId,
+			dto.getCursorComplaintId(),
+			dto.getPageSize()
 		);
 	}
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

* [x] #59 

## 📝 작업 내용

이번 PR에서 작업한 내용을 간략히 설명해주세요

* [x] ⭐️ **API 추가**: `GET /complaint/my/list` — 로그인 사용자가 **직접 작성한** 민원 목록을 커서 기반으로 조회하도록 구현
* [x] ⭐️ **API 추가**: `GET /complaint/my/reacted` — 로그인 사용자가 **공감한** 민원 목록을 커서 기반으로 조회하도록 구현
* [x] **컨트롤러**: `@Valid` 적용 및 엔드포인트 2종 추가, 기존 목록 API에 파라미터 검증 보강
* [x] **DTO**: `MyComplaintListRequestDto`, `MyReactedComplaintListRequestDto` 신설 (`cursorComplaintId`, `pageSize` 포함), `ComplaintListRequestDto.pageSize`는 `@Min(1)` + 기본값 `20` 지정
* [x] **리포지토리**: `ComplaintRepositoryCustom`에 `findMyListWithCursor`, `findReactedListWithCursor` 추가하고 `Impl`에서 댓글/공감 수, 대표 이미지 URL 서브쿼리 포함하여 조회
* [x] **서비스**: `getMyComplaintList(memberId, dto)`, `getMyReactedComplaintList(memberId, dto)` 추가 — 커서/사이즈 전달해 리포지토리 조회 일원화
* [x] **기타**: 목록 DTO 구성 시 place 필드는 매퍼 단계에서 처리하도록 유지(주석 정리)

### 스크린샷 (선택)

